### PR TITLE
Add InheritShippingAddress argument for AuthorizeOnBillingAgreement

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -1968,7 +1968,7 @@ class WC_Amazon_Payments_Advanced_API {
 	 *
 	 * @return boolean
 	 */
-	public function maybe_subscription_is_shippable( WC_Order $order ) {
+	public static function maybe_subscription_is_shippable( WC_Order $order ) {
 
 		if ( ! class_exists( 'WC_Subscriptions_Product' ) ) {
 			return;

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -1976,7 +1976,7 @@ class WC_Amazon_Payments_Advanced_API {
 
 		$items = $order->get_items();
 		if ( empty( $items ) ) {
-			return;
+			return false;
 		}
 
 		$order_shippable = false;

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -1971,7 +1971,7 @@ class WC_Amazon_Payments_Advanced_API {
 	public static function maybe_subscription_is_shippable( WC_Order $order ) {
 
 		if ( ! class_exists( 'WC_Subscriptions_Product' ) ) {
-			return;
+			return false;
 		}
 
 		$items = $order->get_items();

--- a/tests/phpunit/includes/test-wc-amazon-api.php
+++ b/tests/phpunit/includes/test-wc-amazon-api.php
@@ -947,6 +947,7 @@ class WC_Amazon_Payments_Advanced_API_Test extends WP_UnitTestCase {
 				'TransactionTimeout'                  => 0,
 				'SellerOrderAttributes.SellerOrderId' => $order->get_order_number(),
 				'SellerOrderAttributes.StoreName'     => WC_Amazon_Payments_Advanced::get_site_name(),
+				'InheritShippingAddress'              => false,
 			),
 			WC_Amazon_Payments_Advanced_API::get_authorize_recurring_request_args( $order, array(
 				'amazon_billing_agreement_id' => '123',


### PR DESCRIPTION
Send "true" only for subscriptions that are shipping physical products.

### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?

### Changes proposed in this Pull Request:

Add InheritShippingAddress argument for AuthorizeOnBillingAgreement, it send true only when the subscription have shippable products.

Closes # .

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Fix - Add InheritShippingAddress to AuthorizeOnBillingAgreement. InheritShippingAddress = True when orders are shipping physical products.
