### PR TITLE
Add verification of shipping state on update_checkout

### DIFF
--- a/assets/js/amazon-app-widgets.js
+++ b/assets/js/amazon-app-widgets.js
@@ -304,6 +304,17 @@ jQuery( function( $ ) {
 		return window.innerWidth <= 800;
 	}
 
+	function toggleFieldVisibility( type, key ) {
+		var fieldWrapper = $( '#' + type + '_' + key + '_field' ),
+			fieldValue   = $( '#' + type + '_' + key ).val();
+		fieldWrapper.addClass( 'hidden' );
+		$( '.woocommerce-' + type + '-fields' ).addClass( 'hidden' );
+		if ( fieldValue == null || fieldValue == '' ) {
+			fieldWrapper.removeClass( 'hidden' );
+			$( '.woocommerce-' + type + '-fields' ).removeClass( 'hidden' );
+		}
+	}
+
 	function toggleDetailsVisibility( detailsListName ) {
 		if ( $( '.' + detailsListName + '__field-wrapper' ).children( ':not(.hidden)' ).length === 0 ) {
 			$( '.' + detailsListName ).addClass( 'hidden' );
@@ -672,6 +683,7 @@ jQuery( function( $ ) {
 	}
 
 	$( 'body' ).on( 'updated_checkout', function() {
+		toggleFieldVisibility( 'shipping', 'state' );
 		if( ! isAmazonCheckout() ) {
 			return;
 		}

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1277,6 +1277,15 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Payment_Gateway {
 		$shipping_info = WC_Amazon_Payments_Advanced_API::format_address( $destination );
 		// @codingStandardsIgnoreEnd
 
+		// Override Shipping State if Destination State doesn't exists in the country's states list.
+		$order_current_state = $order->get_shipping_state();
+		if ( ! empty( $order_current_state ) && $order_current_state !== $shipping_info['state'] ) {
+			$states = WC()->countries->get_states( $shipping_info['country'] );
+			if ( empty( $states ) || empty( $states[ $shipping_info['state'] ] ) ) {
+				$shipping_info['state'] = $order_current_state;
+			}
+		}
+
 		$order->set_address( $shipping_info, 'shipping' );
 
 		// Some market API endpoint return billing address information, parse it if present.


### PR DESCRIPTION
Show the shipping state if the shipping address state set on Amazon does not match the values in the WC dropdown.

### All Submissions:

* [*] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?

### Changes proposed in this Pull Request:

Change javascript widget to check if shipping state match the values in the WC dropdown. If not, then the shipping fields wrapper and the shipping state will be shown.

Closes # 34.

### How to test the changes in this Pull Request:

1. Add a product to cart and Login with Amazon to checkout
2. Select an address that has a state not expected in WooCommerce (Rome, Lazio for example)
3. Select an address that has a state expected in WooCommerce (Paris, Paris)

### Other information:

* [*] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

- Fix checkout error when address book state does not match WC predefinitions.
