### PR TITLE
Check address change before clean inputs and set address

### DIFF
--- a/assets/js/amazon-app-widgets.js
+++ b/assets/js/amazon-app-widgets.js
@@ -173,6 +173,18 @@ jQuery( function( $ ) {
 		return formattedAddress;
 	}
 
+	function hasShippingAddressChanged( shippingAddress ) {
+		if ( shippingAddress ) {
+			if ( shippingAddress.address_1 === $( '#shipping_address_1' ).val() &&
+			shippingAddress.city === $( '#shipping_city' ).val() &&
+			shippingAddress.postcode === $( '#shipping_postcode' ).val() &&
+			shippingAddress.country === $( '#shipping_country' ).val() ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	function setOrderAddress( prefix, address ) {
 		var fieldList = Object.keys( address );
 		for ( var key in fieldList ) {
@@ -181,7 +193,7 @@ jQuery( function( $ ) {
 		}
 	}
 
-	function clearOrderFormData() {
+	function clearOrderFormData( includeShipping ) {
 		var fieldsToBeCleared = [
 			'billing_first_name',
 			'billing_last_name',
@@ -194,30 +206,34 @@ jQuery( function( $ ) {
 			'billing_state',
 			'billing_country',
 			'billing_email',
-			'shipping_first_name',
-			'shipping_last_name',
-			'shipping_company',
-			'shipping_address_1',
-			'shipping_address_2',
-			'shipping_phone',
-			'shipping_city',
-			'shipping_postcode',
-			'shipping_state',
-			'shipping_country',
 		];
+		if ( includeShipping ) {
+			fieldsToBeCleared.push(
+				'shipping_first_name',
+				'shipping_last_name',
+				'shipping_company',
+				'shipping_address_1',
+				'shipping_address_2',
+				'shipping_phone',
+				'shipping_city',
+				'shipping_postcode',
+				'shipping_state',
+				'shipping_country'
+			);
+		}
 		for ( var field in fieldsToBeCleared ) {
 			editFormInputField( fieldsToBeCleared[ field ], '' );
 		}
 	}
 
 	function setOrderFormData( orderReference ) {
-		clearOrderFormData();
 		var hasShippingAddress = orderReference.Destination && orderReference.Destination.PhysicalDestination;
 		var hasBillingAddress = orderReference.BillingAddress && orderReference.BillingAddress.PhysicalAddress;
 
 		var shippingAddress = ( hasShippingAddress ) ? formatAmazonAddress( orderReference.Destination.PhysicalDestination ) : {};
+		var shippingAddressChanged = hasShippingAddressChanged( shippingAddress );
 		var billingAddress = null;
-
+		clearOrderFormData( shippingAddressChanged );
 		if ( hasBillingAddress ) {
 			billingAddress = formatAmazonAddress( orderReference.BillingAddress.PhysicalAddress );
 		} else {
@@ -232,7 +248,7 @@ jQuery( function( $ ) {
 		billingAddress.phone = billingAddress.phone || orderReference.Buyer.Phone;
 
 		setOrderAddress( 'billing_', billingAddress );
-		if ( hasShippingAddress ) {
+		if ( hasShippingAddress && shippingAddressChanged ) {
 			setOrderAddress( 'shipping_', shippingAddress );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Change javascript widget to check if shipping address change on widget update before clear the shipping address inputs to keep state settings in the whole process. 

Closes #60.

### How to test the changes in this Pull Request:

1. Get to the checkout, login in Amazon Pay
2. Select an address that requires manual correction as described in #54
3. Change the payment method
4. Province field won't be required to re-selecting
5. Change the shipping address that requires manual correction
6. Province field requires re-selecting
7. Pick a test card that will return an error and click "Place Order"
8. After being taken back to the checkout page with the failure message, the user won't have to re-pick the province

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Checkout After picking a province, the user doesn't have to re-select it unless they pick another address in the Amazon widget.
