### PR TITLE
(v1) Avoid domainless redirect URLs

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -712,13 +712,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions extends WC_Gateway_Amazo
 			WC_Amazon_Payments_Advanced_API::cancel_order_reference( $order, 'MFA Failure' );
 
 			// Redirect to cart and amazon logout.
-			$redirect = add_query_arg(
-				array(
-					'amazon_payments_advanced' => 'true',
-					'amazon_logout'            => 'true',
-				),
-				wc_get_cart_url()
-			);
+			$redirect = wc_apa()->get_amazon_logout_url( wc_get_cart_url() );
 
 			// Adds notice and logging.
 			wc_add_notice( __( 'There was a problem authorizing your transaction using Amazon Pay. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1388,13 +1388,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Payment_Gateway {
 			WC_Amazon_Payments_Advanced_API::cancel_order_reference( $order, 'MFA Failure' );
 
 			// Redirect to cart and amazon logout.
-			$redirect = add_query_arg(
-				array(
-					'amazon_payments_advanced' => 'true',
-					'amazon_logout'            => 'true',
-				),
-				wc_get_cart_url()
-			);
+			$redirect = wc_apa()->get_amazon_logout_url( wc_get_cart_url() );
 
 			// Adds notice and logging.
 			wc_add_notice( __( 'There was a problem authorizing your transaction using Amazon Pay. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -212,7 +212,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Payment_Gateway {
 		$label_format           = __( 'This option makes the plugin to work with the latest API from Amazon, this will enable support for Subscriptions and make transactions more securely. <a href="%s" target="_blank">You must create a Login with Amazon App to be able to use this option.</a>', 'woocommerce-gateway-amazon-payments-advanced' );
 		$label_format           = wp_kses( $label_format, array( 'a' => array( 'href' => array(), 'target' => array() ) ) );
 		$enable_login_app_label = sprintf( $label_format, $login_app_setup_url );
-		$redirect_url           = add_query_arg( 'amazon_payments_advanced', 'true', get_permalink( wc_get_page_id( 'checkout' ) ) );
+		$redirect_url           = wc_apa()->get_amazon_payments_checkout_url();
 
 		$this->form_fields = array(
 			'important_note' => array(

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -793,7 +793,11 @@ class WC_Amazon_Payments_Advanced {
 	}
 
 	public function get_amazon_payments_checkout_url() {
-		$url = add_query_arg( array( 'amazon_payments_advanced' => 'true' ), get_permalink( wc_get_page_id( 'checkout' ) ) );
+		$url = get_permalink( wc_get_page_id( 'checkout' ) );
+		if ( empty( $url ) ) {
+			$url = trailingslashit( home_url() );
+		}
+		$url = add_query_arg( array( 'amazon_payments_advanced' => 'true' ), $url );
 		return $url;
 	}
 
@@ -1435,6 +1439,9 @@ class WC_Amazon_Payments_Advanced {
 	public function get_amazon_logout_url( $url = null ) {
 		if ( empty( $url ) ) {
 			$url = get_permalink( wc_get_page_id( 'checkout' ) );
+		}
+		if ( empty( $url ) ) {
+			$url = trailingslashit( home_url() );
 		}
 		return add_query_arg(
 			array(

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -1422,13 +1422,16 @@ class WC_Amazon_Payments_Advanced {
 	 *
 	 * @return string Amazon logout URL
 	 */
-	public function get_amazon_logout_url() {
+	public function get_amazon_logout_url( $url = null ) {
+		if ( empty( $url ) ) {
+			$url = get_permalink( wc_get_page_id( 'checkout' ) );
+		}
 		return add_query_arg(
 			array(
 				'amazon_payments_advanced' => 'true',
 				'amazon_logout'            => 'true',
 			),
-			get_permalink( wc_get_page_id( 'checkout' ) )
+			$url
 		);
 	}
 

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -792,11 +792,21 @@ class WC_Amazon_Payments_Advanced {
 		return $methods;
 	}
 
+	public function get_amazon_payments_checkout_url() {
+		$url = add_query_arg( array( 'amazon_payments_advanced' => 'true' ), get_permalink( wc_get_page_id( 'checkout' ) ) );
+		return $url;
+	}
+
+	public function get_amazon_payments_clean_logout_url() {
+		$url = add_query_arg( array( 'amazon_payments_advanced' => 'true', 'amazon_logout' => false ) );
+		return $url;
+	}
+
 	/**
 	 * Init Amazon login app widget.
 	 */
 	public function init_amazon_login_app_widget() {
-		$redirect_page = is_cart() ? add_query_arg( 'amazon_payments_advanced', 'true', get_permalink( wc_get_page_id( 'checkout' ) ) ) : add_query_arg( array( 'amazon_payments_advanced' => 'true', 'amazon_logout' => false ) );
+		$redirect_page = is_cart() ? $this->get_amazon_payments_checkout_url() : $this->get_amazon_payments_clean_logout_url();
 		?>
 		<script type='text/javascript'>
 		  	function getURLParameter(name, source) {
@@ -854,7 +864,7 @@ class WC_Amazon_Payments_Advanced {
 			'ajax_url'              => admin_url( 'admin-ajax.php' ),
 			'credentials_nonce'     => wp_create_nonce( 'amazon_pay_check_credentials' ),
 			'manual_exchange_nonce' => wp_create_nonce( 'amazon_pay_manual_exchange' ),
-			'login_redirect_url'    => add_query_arg( 'amazon_payments_advanced', 'true', get_permalink( wc_get_page_id( 'checkout' ) ) ),
+			'login_redirect_url'    => $this->get_amazon_payments_checkout_url(),
 		);
 
 		wp_register_script( 'amazon_payments_admin', plugins_url( 'assets/js/amazon-wc-admin' . $js_suffix, __FILE__ ), array(), $this->version, true );
@@ -886,7 +896,7 @@ class WC_Amazon_Payments_Advanced {
 		wp_enqueue_script( 'amazon_payments_advanced_widgets', WC_Amazon_Payments_Advanced_API::get_widgets_url(), array(), $this->version, true );
 		wp_enqueue_script( 'amazon_payments_advanced', plugins_url( 'assets/js/amazon-' . $type . '-widgets' . $js_suffix, __FILE__ ), array(), $this->version, true );
 
-		$redirect_page = is_cart() ? add_query_arg( 'amazon_payments_advanced', 'true', get_permalink( wc_get_page_id( 'checkout' ) ) ) : add_query_arg( array( 'amazon_payments_advanced' => 'true', 'amazon_logout' => false ) );
+		$redirect_page = is_cart() ? $this->get_amazon_payments_checkout_url() : $this->get_amazon_payments_clean_logout_url();
 
 		$params = array(
 			'ajax_url'              => admin_url( 'admin-ajax.php' ),


### PR DESCRIPTION
Normalize and refactor URL handling.

Due to misconfiguration of some stores, where some page (checkout, cart, etc) is not configured properly, resulted in the current URL appended the query strings.

As found in WC itself [here](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-order.php#L1639-L1644), lets default to `home_url()` with the proper trailing slash.

This will avoid the domainless situation noted in issue https://github.com/woocommerce/woocommerce-gateway-amazon-pay/issues/38

v2 will already handle this much better, and avoid Search Engines indexing the redirect URLs.