### PR TITLE
Fix a bunch of v1 issues

### DIFF
--- a/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
+++ b/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
@@ -74,6 +74,9 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 				WC_Amazon_Payments_Advanced_API::refund_payment( $order_id, $id, $amazon_refund_amount, $amazon_refund_note );
 				$this->clear_stored_states( $order_id );
 				break;
+			default:
+				do_action( 'woocommerce_amazon_pa_v1_order_admin_action_' . $action, $order, $id, $action );
+				break;
 		}
 	}
 
@@ -126,7 +129,11 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 		$amazon_capture_id       = get_post_meta( $order_id, 'amazon_capture_id', true );
 		$amazon_refund_ids       = get_post_meta( $order_id, 'amazon_refund_id', false );
 
-		if ( $amazon_capture_id ) {
+		$override = apply_filters( 'woocommerce_amazon_pa_v1_order_admin_actions_panel', false, $order );
+
+		if ( is_array( $override ) ) {
+			$actions = $override['actions'];
+		} elseif ( $amazon_capture_id ) {
 
 			$amazon_capture_state = WC_Amazon_Payments_Advanced_API::get_capture_state( $order_id, $amazon_capture_id );
 

--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -1811,6 +1811,13 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 				/* Translators: 1: refund amount, 2: refund note */
 				$order->add_order_note( sprintf( __( 'Refunded %1$s (%2$s)', 'woocommerce-gateway-amazon-payments-advanced' ), wc_price( $amount ), $note ) );
 
+				wc_create_refund(
+					array(
+						'amount'   => $amount,
+						'reason'   => $note,
+						'order_id' => $order_id,
+					)
+				);
 				add_post_meta( $order_id, 'amazon_refund_id', $refund_id );
 
 				$ret = true;

--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -1471,6 +1471,7 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 			update_post_meta( $order_id, 'amazon_capture_id', str_replace( '-A', '-C', $auth_id ) );
 
 			$order->add_order_note( sprintf( __( 'Captured (Auth ID: %s)', 'woocommerce-gateway-amazon-payments-advanced' ), str_replace( '-A', '-C', $auth_id ) ) );
+			$order->payment_complete();
 		} else {
 			$order->add_order_note( sprintf( __( 'Authorized (Auth ID: %s)', 'woocommerce-gateway-amazon-payments-advanced' ), $auth_id ) );
 		}

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1613,6 +1613,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	}
 
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
+		$process = apply_filters( 'woocommerce_amazon_pa_process_refund', null, $order_id, $amount, $reason );
+		if ( ! is_null( $process ) ) {
+			return $process;
+		}
+
 		$order     = wc_get_order( $order_id );
 		$charge_id = $order->get_meta( 'amazon_charge_id' );
 		if ( empty( $charge_id ) ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1229,7 +1229,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				wc_apa()->ipn_handler->schedule_hook( $charge_id, 'CHARGE' );
 				break;
 			case 'Canceled':
-				$order->update_status( 'pending' );
+				$order->update_status( 'on-hold' );
 				wc_maybe_reduce_stock_levels( $order->get_id() );
 				break;
 			case 'Declined':

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
@@ -27,6 +27,10 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 		add_action( 'woocommerce_subscription_cancelled_' . $id, array( $this, 'cancelled_subscription' ) );
 		add_action( 'woocommerce_subscription_failing_payment_method_updated_' . $id, array( $this, 'update_failing_payment_method' ), 10, 2 );
 
+		add_filter( 'woocommerce_amazon_pa_v1_order_admin_actions_panel', array( $this, 'admin_actions_panel' ), 10, 2 );
+		add_action( 'woocommerce_amazon_pa_v1_order_admin_action_authorize_recurring', array( $this, 'admin_action_authorize_recurring' ), 10, 2 );
+		add_action( 'woocommerce_amazon_pa_v1_order_admin_action_authorize_capture_recurring', array( $this, 'admin_action_authorize_capture_recurring' ), 10, 2 );
+
 		if ( 'v1' === strtolower( $version ) ) { // These are only needed when legacy is the active gateway (prior to migration)
 			add_filter( 'woocommerce_amazon_pa_process_payment', array( $this, 'process_payment' ), 10, 2 );
 			add_filter( 'woocommerce_amazon_pa_get_amazon_order_details', array( $this, 'get_amazon_order_details' ), 10, 2 );
@@ -677,5 +681,77 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 				update_post_meta( $subscription_id, $meta_key, $meta_value );
 			}
 		}
+	}
+
+	public function admin_actions_panel( $ret, $order ) {
+		$actions  = array();
+		$order_id = $order->get_id();
+
+		$amazon_billing_agreement_id = get_post_meta( $order_id, 'amazon_billing_agreement_id', true );
+		if ( empty( $amazon_billing_agreement_id ) ) {
+			return $ret;
+		}
+
+		$amazon_authorization_id = get_post_meta( $order_id, 'amazon_authorization_id', true );
+		$amazon_capture_id       = get_post_meta( $order_id, 'amazon_capture_id', true );
+
+		if ( ! empty( $amazon_authorization_id ) || ! empty( $amazon_capture_id ) ) {
+			return $ret;
+		}
+
+		$status = $this->get_billing_agreement_details( $order_id, $amazon_billing_agreement_id );
+		$amazon_billing_agreement_state = (string) $status->GetBillingAgreementDetailsResult->BillingAgreementDetails->BillingAgreementStatus->State;
+
+		echo wpautop( sprintf( __( 'Billing Agreement %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $amazon_billing_agreement_id ), esc_html( $amazon_billing_agreement_state ) ) );
+
+		switch ( $amazon_billing_agreement_state ) {
+			case 'Open':
+				$actions['authorize_recurring'] = array(
+					'id'     => $amazon_billing_agreement_id,
+					'button' => __( 'Authorize', 'woocommerce-gateway-amazon-payments-advanced' ),
+				);
+
+				$actions['authorize_capture_recurring'] = array(
+					'id'     => $amazon_billing_agreement_id,
+					'button' => __( 'Authorize &amp; Capture', 'woocommerce-gateway-amazon-payments-advanced' ),
+				);
+
+				break;
+			case 'Suspended':
+				echo wpautop( __( 'The agreement has been suspended. Another form of payment is required.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+
+				break;
+			case 'Canceled':
+			case 'Suspended':
+				echo wpautop( __( 'The agreement has been cancelled/closed. No authorizations can be made.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+
+				break;
+		}
+
+		return array(
+			'actions' => $actions,
+		);
+	}
+
+	public function admin_action_authorize_recurring( $order, $amazon_billing_agreement_id ) {
+		$order_id = $order->get_id();
+		delete_post_meta( $order_id, 'amazon_authorization_id' );
+		delete_post_meta( $order_id, 'amazon_capture_id' );
+
+		// $amazon_billing_agreement_id is billing agreement.
+		wc_apa()->log( 'Info: Trying to authorize payment in billing agreement ' . $amazon_billing_agreement_id );
+
+		WC_Amazon_Payments_Advanced_API::authorize_recurring_payment( $order_id, $amazon_billing_agreement_id, false );
+	}
+
+	public function admin_action_authorize_capture_recurring( $order, $amazon_billing_agreement_id ) {
+		$order_id = $order->get_id();
+		delete_post_meta( $order_id, 'amazon_authorization_id' );
+		delete_post_meta( $order_id, 'amazon_capture_id' );
+
+		// $amazon_billing_agreement_id is billing agreement.
+		wc_apa()->log( 'Info: Trying to authorize and capture payment in billing agreement ' . $amazon_billing_agreement_id );
+
+		WC_Amazon_Payments_Advanced_API::authorize_recurring_payment( $order_id, $amazon_billing_agreement_id, true );
 	}
 }

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
@@ -700,7 +700,8 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 		}
 
 		$status = $this->get_billing_agreement_details( $order_id, $amazon_billing_agreement_id );
-		$amazon_billing_agreement_state = (string) $status->GetBillingAgreementDetailsResult->BillingAgreementDetails->BillingAgreementStatus->State;
+
+		$amazon_billing_agreement_state = (string) $status->GetBillingAgreementDetailsResult->BillingAgreementDetails->BillingAgreementStatus->State; // phpcs:ignore WordPress.NamingConventions
 
 		echo wpautop( sprintf( __( 'Billing Agreement %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $amazon_billing_agreement_id ), esc_html( $amazon_billing_agreement_state ) ) );
 

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -226,11 +226,12 @@ class WC_Amazon_Payments_Advanced {
 
 		}
 
+		include_once $this->includes_path . 'legacy/class-wc-gateway-amazon-payments-advanced-legacy.php';
 		if ( WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() ) {
 			include_once $this->includes_path . 'class-wc-gateway-amazon-payments-advanced.php';
 			$this->gateway = new WC_Gateway_Amazon_Payments_Advanced();
+			WC_Gateway_Amazon_Payments_Advanced_Legacy::legacy_hooks();
 		} else {
-			include_once $this->includes_path . 'legacy/class-wc-gateway-amazon-payments-advanced-legacy.php';
 			$this->gateway = new WC_Gateway_Amazon_Payments_Advanced_Legacy();
 		}
 

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -9,7 +9,7 @@
  * Plugin Name: WooCommerce Amazon Pay
  * Plugin URI: https://woocommerce.com/products/pay-with-amazon/
  * Description: Amazon Pay is embedded directly into your existing web site, and all the buyer interactions with Amazon Pay and Login with Amazon take place in embedded widgets so that the buyer never leaves your site. Buyers can log in using their Amazon account, select a shipping address and payment method, and then confirm their order. Requires an Amazon Pay seller account and supports USA, UK, Germany, France, Italy, Spain, Luxembourg, the Netherlands, Sweden, Portugal, Hungary, Denmark, and Japan.
- * Version: 2.0.0-alpha10
+ * Version: 2.0.0-alpha11
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  *


### PR DESCRIPTION
Here's a new build, which includes the following fixes (mostly to v1 issues carried over to v2 legacy handling):

v1: Orders (non subscription) created in confirm for which you did an authorize and capture, did not change the status of the order to processing/completed.
v1: Renewals always triggered a capture. Now they work similar to how things work in v2 (reported by Federico today via DM, and on a 1:1 call).
v1: Subscription orders created with the confirm flow, would not be possible to charge from the admin, since v1 didn't implement any actions depending on the billing agreement (only on the reference_id).
v1: Refunds from WC were duplicating refund entries when the refund amount was lower than the full order amount. Standarized in a way so that it's consistent with v2 (even tho v2 still have a slightly safer implementation).
v2: alpha10 put orders that had a closed authorization as pending payment. The correct status for the order in this case, for consistency with the confirm flow, is the on-hold status.
v2: After migrating keys to v2, v1 refunds were not able to be processed with an error on the browser. (reported by Federico today via DM, and our QA team).