### PR TITLE
Minor fixes before the beta

### DIFF
--- a/includes/admin/class-wc-amazon-payments-advanced-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-admin.php
@@ -191,7 +191,7 @@ class WC_Amazon_Payments_Advanced_Admin {
 					'class'          => 'notice notice-error',
 					'text'           => sprintf(
 						/* translators: 1) The URL to the Amazon Pay settings screen. */
-						'<p>' . __( 'Amazon Pay V2 is now available and migration is required. Please go to your <a href="%1$s">Amazon Pay settings</a> to configure your merchant account', 'woocommerce-gateway-amazon-payments-advanced' ) . '</p>',
+						'<p>' . __( 'Amazon Pay V2 is installed. Please click the "Reconnect to Amazon Pay" button in the <a href="%1$s">Amazon Pay Settings</a> to acquire credentials and complete activation. Amazon Pay V1 will continue to function until you complete this process.', 'woocommerce-gateway-amazon-payments-advanced' ) . '</p>',
 						esc_url( $this->get_settings_url() )
 					),
 					'is_dismissable' => false,
@@ -200,11 +200,7 @@ class WC_Amazon_Payments_Advanced_Admin {
 				$notices[] = array(
 					'dismiss_action' => 'amazon_pay_dismiss_api_migration_notice',
 					'class'          => 'notice notice-error',
-					'text'           => sprintf(
-						/* translators: 1) The URL to the Amazon Pay settings screen. */
-						'<p>' . __( 'Amazon Pay V2 is now available and migration is required. Please click the "Reconnect to Amazon Pay" button to continue.', 'woocommerce-gateway-amazon-payments-advanced' ) . '</p>',
-						esc_url( $this->get_settings_url() )
-					),
+					'text'           => '<p>' . __( 'Amazon Pay V2 is installed. Please click the "Reconnect to Amazon Pay" button below to acquire credentials and complete activation. Amazon Pay V1 will continue to function until you complete this process.', 'woocommerce-gateway-amazon-payments-advanced' ) . '</p>',
 					'is_dismissable' => false,
 				);
 			}

--- a/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
+++ b/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
@@ -72,6 +72,13 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 				$amazon_refund_note   = wc_clean( $_POST['amazon_refund_note'] );
 
 				WC_Amazon_Payments_Advanced_API::refund_payment( $order_id, $id, $amazon_refund_amount, $amazon_refund_note );
+				wc_create_refund(
+					array(
+						'amount'   => $amazon_refund_amount,
+						'reason'   => $amazon_refund_note,
+						'order_id' => $order_id,
+					)
+				);
 				$this->clear_stored_states( $order_id );
 				break;
 			default:

--- a/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
+++ b/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
@@ -91,6 +91,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 		delete_post_meta( $order_id, 'amazon_reference_state' );
 		delete_post_meta( $order_id, 'amazon_capture_state' );
 		delete_post_meta( $order_id, 'amazon_authorization_state' );
+		do_action( 'woocommerce_amazon_pa_v1_cleared_stored_states', $order_id );
 	}
 
 	/**
@@ -120,7 +121,9 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 			return;
 		}
 
-		$actions  = array();
+		$actions  = array(
+			'refresh' => true,
+		);
 		$order_id = $order->get_id();
 
 		// Get ids.
@@ -129,7 +132,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 		$amazon_capture_id       = get_post_meta( $order_id, 'amazon_capture_id', true );
 		$amazon_refund_ids       = get_post_meta( $order_id, 'amazon_refund_id', false );
 
-		$override = apply_filters( 'woocommerce_amazon_pa_v1_order_admin_actions_panel', false, $order );
+		$override = apply_filters( 'woocommerce_amazon_pa_v1_order_admin_actions_panel', false, $order, $actions );
 
 		if ( is_array( $override ) ) {
 			$actions = $override['actions'];
@@ -140,14 +143,12 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 			switch ( $amazon_capture_state ) {
 				case 'Pending':
 					echo wpautop( sprintf( __( 'Capture Reference %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $amazon_capture_id ), esc_html( $amazon_capture_state ) ) );
-					echo $this->get_refresh_link();
 
 					// Admin will need to re-check this, so clear the stored value.
 					$this->clear_stored_states( $order_id );
 					break;
 				case 'Declined':
 					echo wpautop( __( 'The capture was declined.', 'woocommerce-gateway-amazon-payments-advanced' ) );
-					echo $this->get_refresh_link();
 
 					$actions['authorize'] = array(
 						'id'     => $amazon_reference_id,
@@ -167,13 +168,10 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 					</form>
 					<?php
 
-					echo $this->get_refresh_link();
-
 					break;
 				case 'Closed':
 					/* translators: 1) is Amazon Pay capture reference ID, and 2) Amazon Pay capture state */
 					echo wpautop( sprintf( __( 'Capture Reference %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $amazon_capture_id ), esc_html( $amazon_capture_state ) ) );
-					echo $this->get_refresh_link();
 
 					break;
 			}
@@ -224,7 +222,6 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 
 			/* translators: 1) is Amazon Pay authorization reference ID, and 2) Amazon Pay authorization state */
 			echo wpautop( sprintf( __( 'Auth Reference %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $amazon_reference_id ), esc_html( $amazon_authorization_state ) ) );
-			echo $this->get_refresh_link();
 
 			switch ( $amazon_authorization_state ) {
 				case 'Open':
@@ -260,7 +257,6 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 
 			/* translators: 1) is Amazon Pay order reference ID, and 2) Amazon Pay order state */
 			echo wpautop( sprintf( __( 'Order Reference %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $amazon_reference_id ), esc_html( $amazon_reference_state ) ) );
-			echo $this->get_refresh_link();
 
 			switch ( $amazon_reference_state ) {
 				case 'Open':
@@ -285,6 +281,11 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 
 					break;
 			}
+		}
+
+		if ( ! empty( $actions ) && isset( $actions['refresh'] ) ) {
+			echo $this->get_refresh_link();
+			unset( $actions['refresh'] );
 		}
 
 		if ( ! empty( $actions ) ) {

--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -1811,13 +1811,6 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 				/* Translators: 1: refund amount, 2: refund note */
 				$order->add_order_note( sprintf( __( 'Refunded %1$s (%2$s)', 'woocommerce-gateway-amazon-payments-advanced' ), wc_price( $amount ), $note ) );
 
-				wc_create_refund(
-					array(
-						'amount'   => $amount,
-						'reason'   => $note,
-						'order_id' => $order_id,
-					)
-				);
 				add_post_meta( $order_id, 'amazon_refund_id', $refund_id );
 
 				$ret = true;

--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -373,6 +373,11 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 	}
 
 	public function copy_meta_to_sub( $order, $response ) {
+		$version = version_compare( $order->get_meta( 'amazon_payment_advanced_version' ), '2.0.0' ) >= 0 ? 'v2' : 'v1';
+		if ( 'v2' !== strtolower( $version ) ) {
+			return;
+		}
+
 		if ( ! self::order_contains_subscription( $order ) ) {
 			return;
 		}
@@ -402,6 +407,11 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 	}
 
 	public function copy_meta_from_sub( $meta, $order, $subscription ) {
+		$version = version_compare( $subscription->get_meta( 'amazon_payment_advanced_version' ), '2.0.0' ) >= 0 ? 'v2' : 'v1';
+		if ( 'v2' !== strtolower( $version ) ) {
+			return $meta;
+		}
+
 		$meta_keys_to_copy = array(
 			'amazon_charge_permission_id',
 			'amazon_charge_permission_status',

--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -390,7 +390,12 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			}
 			wc_apa()->get_gateway()->log_charge_permission_status_change( $subscription, $response->chargePermissionId ); // phpcs:ignore WordPress.NamingConventions
 			foreach ( $meta_keys_to_copy as $key ) {
-				$subscription->update_meta_data( $key, $order->get_meta( $key ) );
+				$value = $order->get_meta( $key );
+				if ( empty( $value ) ) {
+					continue;
+				}
+
+				$subscription->update_meta_data( $key, $value );
 			}
 			$subscription->save();
 		}
@@ -405,9 +410,14 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 		);
 
 		foreach ( $meta_keys_to_copy as $key ) {
+			$value = $subscription->get_meta( $key );
+			if ( empty( $value ) ) {
+				continue;
+			}
+
 			$meta[] = array(
 				'meta_key'   => $key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value' => $subscription->get_meta( $key ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_value' => $value, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			);
 		}
 		return $meta;

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
@@ -707,15 +707,17 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 
 		switch ( $amazon_billing_agreement_state ) {
 			case 'Open':
-				$actions['authorize_recurring'] = array(
-					'id'     => $amazon_billing_agreement_id,
-					'button' => __( 'Authorize', 'woocommerce-gateway-amazon-payments-advanced' ),
-				);
+				if ( 'shop_order' === $order->get_type() ) {
+					$actions['authorize_recurring'] = array(
+						'id'     => $amazon_billing_agreement_id,
+						'button' => __( 'Authorize', 'woocommerce-gateway-amazon-payments-advanced' ),
+					);
 
-				$actions['authorize_capture_recurring'] = array(
-					'id'     => $amazon_billing_agreement_id,
-					'button' => __( 'Authorize &amp; Capture', 'woocommerce-gateway-amazon-payments-advanced' ),
-				);
+					$actions['authorize_capture_recurring'] = array(
+						'id'     => $amazon_billing_agreement_id,
+						'button' => __( 'Authorize &amp; Capture', 'woocommerce-gateway-amazon-payments-advanced' ),
+					);
+				}
 
 				break;
 			case 'Suspended':

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -9,7 +9,7 @@
  * Plugin Name: WooCommerce Amazon Pay
  * Plugin URI: https://woocommerce.com/products/pay-with-amazon/
  * Description: Amazon Pay is embedded directly into your existing web site, and all the buyer interactions with Amazon Pay and Login with Amazon take place in embedded widgets so that the buyer never leaves your site. Buyers can log in using their Amazon account, select a shipping address and payment method, and then confirm their order. Requires an Amazon Pay seller account and supports USA, UK, Germany, France, Italy, Spain, Luxembourg, the Netherlands, Sweden, Portugal, Hungary, Denmark, and Japan.
- * Version: 2.0.0-alpha11
+ * Version: 2.0.0-alpha12
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  *


### PR DESCRIPTION
Hide buttons on subscriptions (reported by Debbie this morning right before the call).
Implements refresh button/action for CV1 billing agreements, which wasn't implemented in alpha11. This also slightly improves performance, and leaves things consistent with the rest of the CV1 functionality.
Fixes an issue where empty meta corresponding to CV2 would be created on CV1 subscriptions renewals.
Fixes the double refund issue reported by Federico, which was caused by an error in the implementation refactor done in alpha11 yesterday.
Changes copy for the "upgrade credentials" notice, as suggested by Federico after the meeting through DM.