### PR TITLE
Do not remove the keys for hidden_masked fields

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -647,6 +647,20 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	}
 
 	/**
+	 * Get field value.
+	 *
+	 * @param string $key Field key.
+	 * @param array  $value Field value.
+	 * @return string
+	 */
+	public function validate_hidden_masked_field( $key, $value ) {
+		if ( ! empty( $this->settings[ $key ] ) ) {
+			$value = $this->settings[ $key ];
+		}
+		return $value;
+	}
+
+	/**
 	 * Admin Panel Options
 	 * - Options for bits like 'title' and availability on a country-by-country basis
 	 */


### PR DESCRIPTION
The lack of a field, makes Woo think there's an empty field submitted, and therefore wipes the key.