### PR TITLE
Compatibility aelia currency switcher

### DIFF
--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-aelia-currency-switcher.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-aelia-currency-switcher.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Main class to handle Aelia Currency Switcher for WooCommerce compatibility.
+ * Tested up to: Aelia Currency Switcher 4.9.14.210215.
+ *
+ * @package WC_Gateway_Amazon_Pay\Compats
+ * @link https://aelia.co/shop/currency-switcher-woocommerce/
+ */
+
+/**
+ * WooCommerce Aelia Currency Switcher for WooCommerce Multi-currency compatibility.
+ *
+ * @author Aelia
+ * @link https://aelia.co/shop/currency-switcher-woocommerce/
+ */
+class WC_Amazon_Payments_Advanced_Multi_Currency_Aelia_Currency_Switcher extends WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
+	/**
+	 * Holds Aelia Currency Switcher instance.
+	 *
+	 * @var Aelia\WC\CurrencySwitcher\WC_Aelia_CurrencySwitcher
+	 */
+	protected $currency_switcher;
+
+	/**
+	 * Specify hooks where compatibility action takes place.
+	 */
+	public function __construct() {
+		$this->currency_switcher = $GLOBALS['woocommerce-aelia-currencyswitcher'];
+		add_filter( 'init', array( $this, 'remove_shortcode_currency_switcher_on_order_reference_suspended' ) );
+
+		parent::__construct();
+	}
+
+
+	/**
+	 * Get the selected currency from the Currency Switcher.
+	 *
+	 * @return string
+	 */
+	public function get_selected_currency() {
+		return $this->currency_switcher->get_selected_currency();
+	}
+
+	/**
+	 * The name of this method is misleading. It should return "true" if the multi-currency
+	 * plugin only DISPLAYS prices in multiple currencies, but the transactions occur in
+	 * a single currency. The Aelia Currency Switcher always ensures that transactions are
+	 * completed in the currency used to place an order, therefore this method should return
+	 * false.
+	 *
+	 * @return bool
+	 */
+	public function is_front_end_compatible() {
+		return false;
+	}
+
+	/**
+	 * On OrderReferenceStatus === Suspended, hide currency switcher.
+	 */
+	// TODO Clarify what this method does
+	public function remove_shortcode_currency_switcher_on_order_reference_suspended( $value ) {
+		if ( $this->is_order_reference_checkout_suspended() ) {
+			// By Pass Multi-currency, so we don't trigger a new set_order_reference_details on process_payment
+			$this->bypass_currency_session();
+		}
+	}
+
+}

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
@@ -23,6 +23,9 @@ class WC_Amazon_Payments_Advanced_Multi_Currency {
 		'class_WC_Product_Price_Based_Country' => 'Price Based on Country for WooCommerce',
 		'global_woocommerce_wpml'              => 'WPML WooCommerce Multilingual',
 		'class_WC_Currency_Converter'          => 'Currency Converter Widget',
+		// Aelia Currency Switcher
+		// @author Aelia <support@aelia.co>
+		'class_Aelia\WC\CurrencySwitcher\WC_Aelia_CurrencySwitcher' => 'Aelia Currency Switcher',
 	);
 
 	/**
@@ -68,6 +71,12 @@ class WC_Amazon_Payments_Advanced_Multi_Currency {
 						require_once 'class-wc-amazon-payments-advanced-multi-currency-wccw.php';
 						self::$compatible_instance = new WC_Amazon_Payments_Advanced_Multi_Currency_Converted_Widget();
 						break;
+					// Aelia Currency Switcher
+					// @author Aelia <support@aelia.co>
+					case 'class_Aelia\WC\CurrencySwitcher\WC_Aelia_CurrencySwitcher':
+						require_once 'class-wc-amazon-payments-advanced-multi-currency-aelia-currency-switcher.php';
+						self::$compatible_instance = new WC_Amazon_Payments_Advanced_Multi_Currency_Aelia_Currency_Switcher();
+						break;
 				}
 			}
 		}
@@ -87,7 +96,7 @@ class WC_Amazon_Payments_Advanced_Multi_Currency {
 
 	/**
 	 * Singleton to get if there is a compatible instance running. Region can be injected.
-	 * 
+	 *
 	 * @param bool $region
 	 *
 	 * @return WC_Amazon_Payments_Advanced_Multi_Currency_Abstract

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
@@ -19,13 +19,20 @@ class WC_Amazon_Payments_Advanced_Multi_Currency {
 	 * List of compatible plugins, with its global variable name or main class.
 	 */
 	const COMPATIBLE_PLUGINS = array(
+		// Aelia Currency Switcher
+		//
+		// Note
+		// The Aelia Currency Switcher integration must come before the WooCommerce Multilingual one.
+		// This is needed because this integration class stops as soon as it finds one of the supported
+		// plugins. If it finds the WooCommerce Multilingual, it will not look for any other, even if
+		// the multi-currency features in WCML are disabled. In that case, the integration with the
+		// Aelia Currency Switcher would not be loaded, even though the plugin is active and running.
+		// @author Aelia <support@aelia.co>
+		'class_Aelia\WC\CurrencySwitcher\WC_Aelia_CurrencySwitcher' => 'Aelia Currency Switcher',
 		'global_WOOCS'                         => 'WOOCS – Currency Switcher for WooCommerce',
 		'class_WC_Product_Price_Based_Country' => 'Price Based on Country for WooCommerce',
 		'global_woocommerce_wpml'              => 'WPML WooCommerce Multilingual',
 		'class_WC_Currency_Converter'          => 'Currency Converter Widget',
-		// Aelia Currency Switcher
-		// @author Aelia <support@aelia.co>
-		'class_Aelia\WC\CurrencySwitcher\WC_Aelia_CurrencySwitcher' => 'Aelia Currency Switcher',
 	);
 
 	/**


### PR DESCRIPTION
I've been asked by my client to open a new pull request, since the PR sent to the WooCommerce Team was closed, probably by mistake, without a merge.

### All Submissions:

* [ ] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards? **I think so, but can't say, the link to the standards can't be reached.**
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:
Integration with the Aelia Currency Switcher, for multi-currency support. We proposed the same integration a few months ago to Sau/Cal, but it hasn't been added to the Amazon Pay plugin, yet.

### How to test the changes in this Pull Request:
1. Install and configure the Aelia Currency Switcher (free copy available on request), enabling multiple currencies.
2. Go to WooCommerce > Settings > Payments > Amazon Pay.
3. Verify that the integration is active (see https://prnt.sc/10d2jg0). 
4. Enable Amazon Pay for some currencies in the gateway settings.
5. Enable Amazon Pay for the same currencies at WooCommerce > Currency Switcher > Payment Gateways (see https://prnt.sc/10d2izo).
6. Place an order in the enabled currencies, paying with Amazon. and verify that it's processed correctly.

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Added integration with the Aelia Currency Switcher, for multi-currency support.
