### PR TITLE
Change php version for travis to check against.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 
 # Test main supported versions of PHP and HHVM against latest WP. 5.2 is min supported version.
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 services:
   - mysql

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "woocommerce/woocommerce-sniffs": "0.1.0",
         "php-stubs/woocommerce-stubs": "^5.1",
         "szepeviktor/phpstan-wordpress": "^0.7.5",
-        "phpstan/extension-installer": "^1.1"
+        "phpstan/extension-installer": "^1.1",
+        "yoast/phpunit-polyfills": "^1.0"
     },
     "require": {
         "amzn/amazon-pay-api-sdk-php": "^2.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1ff613c3cb9c03419b25ac6dfdd7968",
+    "content-hash": "ccc818de473a1c3287aea6fa5079ac84",
     "packages": [
         {
             "name": "amzn/amazon-pay-api-sdk-php",
@@ -2442,6 +2442,67 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-10-03T08:40:26+00:00"
         }
     ],
     "aliases": [],
@@ -2454,5 +2515,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Fix issues #126 produced by the inclusion of phpstan/extension-installer:
Changes the version of php for travis checks since phpStan extension-installer requires ^php 7.1 in order to work, and as we  are setting the composer to php 7.3, I added that version too.
