### PR TITLE
Replace gateways object to avoid error on settings

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -949,7 +949,8 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	 * @return bool
 	 */
 	public function has_other_gateways_enabled() {
-		$gateways = WC()->payment_gateways()->get_available_payment_gateways();
+		$wc_gateways = new WC_Payment_Gateways();
+		$gateways    = $wc_gateways->get_available_payment_gateways();
 		unset( $gateways['amazon_payments_advanced'] );
 		if ( ! empty( $gateways ) ) {
 			foreach ( $gateways as $gateway ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2301,11 +2301,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 * Maybe hide standard WC checkout button on the cart, if enabled
 	 */
 	public function maybe_hide_standard_checkout_button() {
-		if ( ! $this->is_available() ) {
+		if ( ! $this->is_available() || $this->has_other_gateways_enabled() ) {
 			return;
 		}
 
-		if ( 'yes' !== $this->settings['hide_standard_checkout_button'] || $this->has_other_gateways_enabled() ) {
+		if ( 'yes' !== $this->settings['hide_standard_checkout_button'] ) {
 			return;
 		}
 

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -224,6 +224,8 @@ class WC_Amazon_Payments_Advanced {
 
 		}
 
+		add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateway' ) );
+
 		include_once $this->includes_path . 'legacy/class-wc-gateway-amazon-payments-advanced-legacy.php';
 		if ( WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() ) {
 			include_once $this->includes_path . 'class-wc-gateway-amazon-payments-advanced.php';
@@ -232,8 +234,7 @@ class WC_Amazon_Payments_Advanced {
 		} else {
 			$this->gateway = new WC_Gateway_Amazon_Payments_Advanced_Legacy();
 		}
-
-		add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateway' ) );
+		$this->gateway->gateway_settings_init();
 	}
 
 	/**


### PR DESCRIPTION
Fix bug we introduced in this fix https://github.com/woocommerce/woocommerce-gateway-amazon-pay/pull/127/commits/314c602df5868492ff960865e2459cb91722f54c that hides the gateway on the new installs.