### PR TITLE
Force Decimals to 2 on amounts sent to API

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -297,7 +297,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			if ( 1 === $subscriptions_in_cart ) {
 				$first_recurring                        = reset( WC()->cart->recurring_carts );
 				$payload['recurringMetadata']['amount'] = array(
-					'amount'       => $first_recurring->get_total( 'edit' ),
+					'amount'       => number_format( $first_recurring->get_total( 'edit' ), 2 ),
 					'currencyCode' => get_woocommerce_currency(),
 				);
 			}
@@ -323,7 +323,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['recurringMetadata'] = array(
 				'frequency' => $this->parse_interval_to_apa_frequency( $subscription->get_billing_period( 'edit' ), $subscription->get_billing_interval( 'edit' ) ),
 				'amount'    => array(
-					'amount'       => $subscription->get_total(),
+					'amount'       => number_format( $subscription->get_total(), 2 ),
 					'currencyCode' => wc_apa_get_order_prop( $subscription, 'order_currency' ),
 				),
 			);
@@ -347,7 +347,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$payload['paymentDetails']['chargeAmount'] = $checkout_session->recurringMetadata->amount; // phpcs:ignore WordPress.NamingConventions
+			$payload['paymentDetails']['chargeAmount'] = number_format( $checkout_session->recurringMetadata->amount, 2 ); // phpcs:ignore WordPress.NamingConventions
 
 			return $payload;
 		}
@@ -379,7 +379,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		if ( 1 === $subscriptions_in_cart ) {
 			$payload['recurringMetadata']['amount'] = array(
-				'amount'       => $recurring_total,
+				'amount'       => number_format( $recurring_total, 2 ),
 				'currencyCode' => wc_apa_get_order_prop( $order, 'order_currency' ),
 			);
 		}
@@ -388,7 +388,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$payload['paymentDetails']['chargeAmount']['amount'] = $recurring_total;
+			$payload['paymentDetails']['chargeAmount']['amount'] = number_format( $recurring_total, 2 );
 		}
 
 		return $payload;
@@ -425,7 +425,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		$recurring_total = wc_format_decimal( $recurring_total, '' );
 
-		$payload['chargeAmount']['amount'] = $recurring_total;
+		$payload['chargeAmount']['amount'] = number_format( $recurring_total, 2 );
 
 		return $payload;
 	}
@@ -544,7 +544,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => $amount_to_charge,
+					'amount'       => number_format( $amount_to_charge, 2 ),
 					'currencyCode' => $currency,
 				),
 			)

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1172,7 +1172,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			 * }
 			 */
 
-			$order_total = $order->get_total();
+			$order_total = number_format( $order->get_total(), 2 );
 			$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
 
 			wc_apa()->log( "Info: Beginning processing of payment for order {$order_id} for the amount of {$order_total} {$currency}. Checkout Session ID: {$checkout_session_id}." );
@@ -1262,7 +1262,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$order = wc_get_order( $order_id );
 
-		$order_total = $order->get_total();
+		$order_total = number_format( $order->get_total(), 2 );
 		$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
 
 		wc_apa()->log( "Completing checkout session data for #{$order_id}." );
@@ -2128,7 +2128,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => $order->get_total(),
+					'amount'       => number_format( $order->get_total(), 2 ),
 					'currencyCode' => $currency,
 				),
 			)


### PR DESCRIPTION
Fix issue #120
Force Decimals to 2 on amounts sent to API to prevent errors on api calls.
WooCommerce support more that 2 digit on their setting, this enables merchants to connect with some ERP systems that required this due to rounding issues. 