### PR TITLE
fix: fatal error on Amazon API errors

### DIFF
--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -180,6 +180,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 
 		$charge_permission_status_label = $this->status_details_label( $charge_permission_cached_status );
 
+		$charge_permission_status_label = $charge_permission_status_label ? $charge_permission_status_label : __( 'Invalid', 'woocommerce-gateway-amazon-payments-advanced' );
 		/* translators: 1) Charge Permission ID 2) Status. */
 		echo wpautop( sprintf( __( 'Charge Permission %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $charge_permission_id ), esc_html( $charge_permission_status_label ) ) );
 
@@ -214,7 +215,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 			$charge_cached_status = wc_apa()->get_gateway()->get_cached_charge_status( $order );
 
 			$charge_status_label = $this->status_details_label( $charge_cached_status );
-
+			$charge_status_label = $charge_status_label ? $charge_status_label : __( 'Invalid', 'woocommerce-gateway-amazon-payments-advanced' );
 			/* translators: 1) Charge ID 2) Status. */
 			echo wpautop( sprintf( __( 'Charge %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $charge_id ), esc_html( $charge_status_label ) ) );
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1882,6 +1882,10 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			$charge_permission_id = $charge_permission->chargePermissionId; // phpcs:ignore WordPress.NamingConventions
 		}
 
+		if ( is_wp_error( $charge_permission ) ) {
+			return $charge_permission;
+		}
+
 		$charge_permission_status       = $this->format_status_details( $charge_permission->statusDetails ); // phpcs:ignore WordPress.NamingConventions
 		$charge_permission_status->type = $charge_permission->chargePermissionType; // phpcs:ignore WordPress.NamingConventions
 

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
@@ -384,13 +384,13 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 		} catch ( Exception $e ) {
 			wc_apa()->log( "Error: Exception encountered in 'GetBillingAgreementDetails': {$e->getMessage()}" );
 
-			$return = new WP_Error();
-			$return->add(
+			$return = new WP_Error(
 				'billing_agreemment_details_failed',
 				is_object( $response ) && ! empty( $response->Error ) && is_object( $response->Error->Message ) && ! empty( $response->Error->Message ) ?
 				$response->Error->Message :
 				sprintf( __( 'Amazon API responded with an unexpected error when requesting for "GetBillingAgreementDetails" of billing agreement with ID %s', 'woocommerce-gateway-amazon-payments-advanced' ), $amazon_billing_agreement_id )
 			);
+			return $return;
 		}
 		return $response;
 	}

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
@@ -97,6 +97,10 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 
 			// Get the Billing Agreement Details, with FULL address (now that we've confirmed).
 			$result = $this->get_billing_agreement_details( $order_id, $amazon_billing_agreement_id );
+			if ( is_wp_error( $result ) ) {
+				$error_msg = $result->get_error_message( 'billing_agreemment_details_failed' ) ? $result->get_error_message( 'billing_agreemment_details_failed' ) : $result->get_error_message();
+				throw new Exception( $error_msg );
+			}
 
 			// Store the subscription destination.
 			$this->store_subscription_destination( $order_id, $result );
@@ -202,9 +206,13 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 		$response = WC_Amazon_Payments_Advanced_API_Legacy::request( $request_args );
 		$order_id = wc_apa_get_order_prop( $order, 'id' );
 
-		$this->handle_generic_api_response_errors( __METHOD__, $response, $order_id, $amazon_billing_agreement_id );
+		try {
+			$this->handle_generic_api_response_errors( __METHOD__, $response, $order_id, $amazon_billing_agreement_id );
 
-		wc_apa()->log( "Info: SetBillingAgreementDetails for order {$order_id} with billing agreement: {$amazon_billing_agreement_id}." );
+			wc_apa()->log( "Info: SetBillingAgreementDetails for order {$order_id} with billing agreement: {$amazon_billing_agreement_id}." );
+		} catch ( Exception $e ) {
+			wc_apa()->log( "Error: Exception encountered in 'SetBillingAgreementDetails': {$e->getMessage()}" );
+		}
 
 		return $response;
 
@@ -237,10 +245,13 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 		}
 
 		$response = WC_Amazon_Payments_Advanced_API_Legacy::request( $confirm_args );
+		try {
+			$this->handle_generic_api_response_errors( __METHOD__, $response, $order_id, $amazon_billing_agreement_id );
 
-		$this->handle_generic_api_response_errors( __METHOD__, $response, $order_id, $amazon_billing_agreement_id );
-
-		wc_apa()->log( "Info: ConfirmBillingAgreement for Billing Agreement ID: {$amazon_billing_agreement_id}." );
+			wc_apa()->log( "Info: ConfirmBillingAgreement for Billing Agreement ID: {$amazon_billing_agreement_id}." );
+		} catch ( Exception $e ) {
+			wc_apa()->log( "Error: Exception encountered in 'ConfirmBillingAgreement': {$e->getMessage()}" );
+		}
 
 		return $response;
 
@@ -366,9 +377,21 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 			)
 		);
 
-		$this->handle_generic_api_response_errors( __METHOD__, $response, $order_id, $amazon_billing_agreement_id );
+		try {
+			$this->handle_generic_api_response_errors( __METHOD__, $response, $order_id, $amazon_billing_agreement_id );
 
-		wc_apa()->log( "Info: GetBillingAgreementDetails for Billing Agreement ID: {$amazon_billing_agreement_id}." );
+			wc_apa()->log( "Info: GetBillingAgreementDetails for Billing Agreement ID: {$amazon_billing_agreement_id}." );
+		} catch ( Exception $e ) {
+			wc_apa()->log( "Error: Exception encountered in 'GetBillingAgreementDetails': {$e->getMessage()}" );
+
+			$return = new WP_Error();
+			$return->add(
+				'billing_agreemment_details_failed',
+				is_object( $response ) && ! empty( $response->Error ) && is_object( $response->Error->Message ) && ! empty( $response->Error->Message ) ?
+				$response->Error->Message :
+				sprintf( __( 'Amazon API responded with an unexpected error when requesting for "GetBillingAgreementDetails" of billing agreement with ID %s', 'woocommerce-gateway-amazon-payments-advanced' ), $amazon_billing_agreement_id )
+			);
+		}
 		return $response;
 	}
 
@@ -607,7 +630,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 			/* translators: 1) Reason. */
 			$order->add_order_note( sprintf( __( 'Amazon Pay subscription renewal failed - %s', 'woocommerce-gateway-amazon-payments-advanced' ), $e->getMessage() ) );
 
-			wc_apa()->log( "Error: Exception encountered: {$e->getMessage()}" );
+			wc_apa()->log( "Error: Exception encountered trying to renew subscription with Amazon Pay: {$e->getMessage()}" );
 		}
 	}
 
@@ -651,7 +674,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 
 				wc_apa()->log( "Info: CloseBillingAgreement for order {$order_id} with billing agreement: {$amazon_billing_agreement_id}." );
 			} catch ( Exception $e ) {
-				wc_apa()->log( "Error: Exception encountered: {$e->getMessage()}" );
+				wc_apa()->log( "Error: Exception encountered in 'CloseBillingAgreement': {$e->getMessage()}" );
 
 				/* translators: placeholder is error message from Amazon Pay API */
 				$order->add_order_note( sprintf( __( "Exception encountered in 'CloseBillingAgreement': %s", 'woocommerce-gateway-amazon-payments-advanced' ), $e->getMessage() ) );

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
@@ -384,13 +384,12 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 		} catch ( Exception $e ) {
 			wc_apa()->log( "Error: Exception encountered in 'GetBillingAgreementDetails': {$e->getMessage()}" );
 
-			$return = new WP_Error(
+			return new WP_Error(
 				'billing_agreemment_details_failed',
 				is_object( $response ) && ! empty( $response->Error ) && is_object( $response->Error->Message ) && ! empty( $response->Error->Message ) ?
 				$response->Error->Message :
 				sprintf( __( 'Amazon API responded with an unexpected error when requesting for "GetBillingAgreementDetails" of billing agreement with ID %s', 'woocommerce-gateway-amazon-payments-advanced' ), $amazon_billing_agreement_id )
 			);
-			return $return;
 		}
 		return $response;
 	}


### PR DESCRIPTION
- Adds the "Invalid " label in auth_box_render.
- Checks if $charge_permission is WP_Error before trying to access props in refresh_cached_charge_permission_status
- Handles the exceptions that could be thrown from handle_generic_api_response_errors and if not catched would cause fatal errors

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .
https://app.clickup.com/t/1p82xxm
https://github.com/woocommerce/woocommerce-gateway-amazon-pay/issues/115

### How to test the changes in this Pull Request:

1. Visit an order or a subscription paid using Amazon Pay that would throw an exception causing a fatal error
2. It would no longer cause an error, and the label of the billing agreement would be Invalid
