### PR TITLE
fix: check for wp_error before requesting status_details_label

### DIFF
--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -184,7 +184,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 		/* translators: 1) Charge Permission ID 2) Status. */
 		echo wpautop( sprintf( __( 'Charge Permission %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $charge_permission_id ), esc_html( $charge_permission_status_label ) ) );
 
-		$charge_permission_status = $charge_permission_cached_status->status;
+		$charge_permission_status = ! is_wp_error( $charge_permission_cached_status ) ? $charge_permission_cached_status->status : '';
 
 		switch ( $charge_permission_status ) {
 			case 'Chargeable':

--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -178,7 +178,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 
 		$charge_permission_cached_status = wc_apa()->get_gateway()->get_cached_charge_permission_status( $order );
 
-		$charge_permission_status_label = $this->status_details_label( $charge_permission_cached_status );
+		$charge_permission_status_label = ! is_wp_error( $charge_permission_cached_status ) ? $this->status_details_label( $charge_permission_cached_status ) : false;
 
 		$charge_permission_status_label = $charge_permission_status_label ? $charge_permission_status_label : __( 'Invalid', 'woocommerce-gateway-amazon-payments-advanced' );
 		/* translators: 1) Charge Permission ID 2) Status. */


### PR DESCRIPTION
Avoids php warnings by checking if $charge_permission_cached_status is WP_Error before passing it to status_details_label

