### PR TITLE
Bug Fixing (#135)

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -123,7 +123,6 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 		$this->method_description   = __( 'Amazon Pay is embedded directly into your existing web site, and all the buyer interactions with Amazon Pay and Login with Amazon take place in embedded widgets so that the buyer never leaves your site. Buyers can log in using their Amazon account, select a shipping address and payment method, and then confirm their order. Requires an Amazon Pay seller account and supports USA, UK, Germany, France, Italy, Spain, Luxembourg, the Netherlands, Sweden, Portugal, Hungary, Denmark, and Japan.', 'woocommerce-gateway-amazon-payments-advanced' );
 		$this->id                   = 'amazon_payments_advanced';
 		$this->icon                 = apply_filters( 'woocommerce_amazon_pa_logo', wc_apa()->plugin_url . '/assets/images/amazon-payments.png' );
-		$this->debug                = ( 'yes' === $this->get_option( 'debug' ) );
 		$this->view_transaction_url = $this->get_transaction_url_format();
 		$this->supports             = array(
 			'products',
@@ -132,17 +131,27 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 		$this->supports             = apply_filters( 'woocommerce_amazon_pa_supports', $this->supports, $this );
 		$this->private_key          = get_option( WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::KEYS_OPTION_PRIVATE_KEY );
 
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'validate_api_keys' ) );
+
+		add_action( 'woocommerce_amazon_checkout_init', array( $this, 'checkout_init_common' ) );
+
+	}
+
+	/**
+	 * Gateway Settings Init
+	 *
+	 * @since 2.3.4
+	 */
+	public function gateway_settings_init() {
 		// Load the settings.
 		$this->init_settings();
 
 		// Load saved settings.
 		$this->load_settings();
 
-		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
-		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'validate_api_keys' ) );
-
-		add_action( 'woocommerce_amazon_checkout_init', array( $this, 'checkout_init_common' ) );
-
+		// Set Debug option.
+		$this->debug = ( 'yes' === $this->get_option( 'debug' ) );
 	}
 
 	/**
@@ -487,7 +496,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 
 		$this->form_fields = apply_filters( 'woocommerce_amazon_pa_form_fields_before_legacy', $this->form_fields );
 
-		if ( $this->has_v1_settings() ) {
+		if ( $this->has_v1_settings() && ! WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() ) {
 			$this->form_fields = array_merge(
 				$this->form_fields,
 				array(

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -224,6 +224,8 @@ class WC_Amazon_Payments_Advanced {
 
 		}
 
+		add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateway' ) );
+
 		include_once $this->includes_path . 'legacy/class-wc-gateway-amazon-payments-advanced-legacy.php';
 		if ( WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() ) {
 			include_once $this->includes_path . 'class-wc-gateway-amazon-payments-advanced.php';
@@ -232,8 +234,7 @@ class WC_Amazon_Payments_Advanced {
 		} else {
 			$this->gateway = new WC_Gateway_Amazon_Payments_Advanced_Legacy();
 		}
-
-		add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateway' ) );
+		$this->gateway->gateway_settings_init();
 	}
 
 	/**


### PR DESCRIPTION
* Check if other gateways is enabled before hide checkout button issue #97

* Enable subscription amount change support Issue #106

* Accept states without letters mark variations on shipping restriction - Issue #122

* Render cart button on update shipping method

* Unify version checker

* Get order charge permission and charge id method

* Force v2 version on orders

* Remove duplicated assignation

* Add charge id for the orders with open capture

* Parse V1 ipn response to process it with V2 handler

* Skip v1 IPN handler on migration done

* Lowercase version on parsed IPN notification

* Change string replace function and save order

* Log notification Data for the V1 IPN

* Fix typos

* PHPCS issues

* PHPCS manual fixes

* PHPCS fixes

* Fix function call.

* Undo version change

* Replace gateways object to avoid error on settings

* Set Order Transaction Id

(Saucal Issue #125)

* Force Decimals to 2 on amounts sent to API

* Hide API V1 settings after onboarding is made

* Check other gateways existence early

* Delay Init settings to ensure gateway addition

* Add correct transaction Id to subscription and renewals orders

Co-authored-by: Matias Saggiorato <saggiorato@saucal.com>
Co-authored-by: Matias Saggiorato <matiassaggiorato@gmail.com>

### All Submissions:

* [ ] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
