### PR TITLE
fix: no demicals when JPY is used as the currency

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -295,10 +295,13 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			);
 
 			if ( 1 === $subscriptions_in_cart ) {
+				$currency_code = get_woocommerce_currency();
+				$demicals      = 'JPY' === $currency_code ? 0 : 2;
+
 				$first_recurring                        = reset( WC()->cart->recurring_carts );
 				$payload['recurringMetadata']['amount'] = array(
-					'amount'       => number_format( $first_recurring->get_total( 'edit' ), 2 ),
-					'currencyCode' => get_woocommerce_currency(),
+					'amount'       => number_format( $first_recurring->get_total( 'edit' ), $demicals ),
+					'currencyCode' => $currency_code,
 				);
 			}
 		} elseif ( $cart_contains_renewal || $change_payment_for_subscription ) {
@@ -320,11 +323,14 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 			$payload['chargePermissionType'] = 'Recurring';
 
+			$currency_code = wc_apa_get_order_prop( $subscription, 'order_currency' );
+			$demicals      = 'JPY' === $currency_code ? 0 : 2;
+
 			$payload['recurringMetadata'] = array(
 				'frequency' => $this->parse_interval_to_apa_frequency( $subscription->get_billing_period( 'edit' ), $subscription->get_billing_interval( 'edit' ) ),
 				'amount'    => array(
-					'amount'       => number_format( $subscription->get_total(), 2 ),
-					'currencyCode' => wc_apa_get_order_prop( $subscription, 'order_currency' ),
+					'amount'       => number_format( $subscription->get_total(), $demicals ),
+					'currencyCode' => $currency_code,
 				),
 			);
 		}
@@ -347,7 +353,10 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$payload['paymentDetails']['chargeAmount'] = number_format( $checkout_session->recurringMetadata->amount, 2 ); // phpcs:ignore WordPress.NamingConventions
+			$currency_code = ! empty( $payload['paymentDetails']['currencyCode'] ) ? $payload['paymentDetails']['currencyCode'] : wc_apa_get_order_prop( $order, 'order_currency' );
+			$demicals      = 'JPY' === $currency_code ? 0 : 2;
+
+			$payload['paymentDetails']['chargeAmount'] = number_format( $checkout_session->recurringMetadata->amount, $demicals ); // phpcs:ignore WordPress.NamingConventions
 
 			return $payload;
 		}
@@ -378,9 +387,11 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 		$recurring_total = wc_format_decimal( $recurring_total, '' );
 
 		if ( 1 === $subscriptions_in_cart ) {
+			$currency_code = wc_apa_get_order_prop( $order, 'order_currency' );
+			$demicals      = 'JPY' === $currency_code ? 0 : 2;
 			$payload['recurringMetadata']['amount'] = array(
-				'amount'       => number_format( $recurring_total, 2 ),
-				'currencyCode' => wc_apa_get_order_prop( $order, 'order_currency' ),
+				'amount'       => number_format( $recurring_total, $demicals ),
+				'currencyCode' => $currency_code,
 			);
 		}
 
@@ -388,7 +399,10 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$payload['paymentDetails']['chargeAmount']['amount'] = number_format( $recurring_total, 2 );
+			$currency_code = ! empty( $payload['paymentDetails']['currencyCode'] ) ? $payload['paymentDetails']['currencyCode'] : wc_apa_get_order_prop( $order, 'order_currency' );
+			$demicals      = 'JPY' === $currency_code ? 0 : 2;
+
+			$payload['paymentDetails']['chargeAmount']['amount'] = number_format( $recurring_total, $demicals );
 		}
 
 		return $payload;
@@ -425,7 +439,10 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		$recurring_total = wc_format_decimal( $recurring_total, '' );
 
-		$payload['chargeAmount']['amount'] = number_format( $recurring_total, 2 );
+		$currency_code = ! empty( $payload['paymentDetails']['currencyCode'] ) ? $payload['paymentDetails']['currencyCode'] : get_woocommerce_currency();
+		$demicals      = 'JPY' === $currency_code ? 0 : 2;
+
+		$payload['chargeAmount']['amount'] = number_format( $recurring_total, $demicals );
 
 		return $payload;
 	}
@@ -536,6 +553,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 		}
 
 		$currency = wc_apa_get_order_prop( $order, 'order_currency' );
+		$demicals = 'JPY' === $currency ? 0 : 2;
 
 		$response = WC_Amazon_Payments_Advanced_API::create_charge(
 			$charge_permission_id,
@@ -544,7 +562,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => number_format( $amount_to_charge, 2 ),
+					'amount'       => number_format( $amount_to_charge, $demicals ),
 					'currencyCode' => $currency,
 				),
 			)

--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -297,7 +297,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			if ( 1 === $subscriptions_in_cart ) {
 				$first_recurring                        = reset( WC()->cart->recurring_carts );
 				$payload['recurringMetadata']['amount'] = array(
-					'amount'       => number_format( $first_recurring->get_total( 'edit' ), 2 ),
+					'amount'       => number_format( $first_recurring->get_total( 'edit' ), min( wc_get_price_decimals(), 2 ) ),
 					'currencyCode' => get_woocommerce_currency(),
 				);
 			}
@@ -323,7 +323,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['recurringMetadata'] = array(
 				'frequency' => $this->parse_interval_to_apa_frequency( $subscription->get_billing_period( 'edit' ), $subscription->get_billing_interval( 'edit' ) ),
 				'amount'    => array(
-					'amount'       => number_format( $subscription->get_total(), 2 ),
+					'amount'       => number_format( $subscription->get_total(), min( wc_get_price_decimals(), 2 ) ),
 					'currencyCode' => wc_apa_get_order_prop( $subscription, 'order_currency' ),
 				),
 			);
@@ -347,7 +347,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$payload['paymentDetails']['chargeAmount'] = number_format( $checkout_session->recurringMetadata->amount, 2 ); // phpcs:ignore WordPress.NamingConventions
+			$payload['paymentDetails']['chargeAmount'] = number_format( $checkout_session->recurringMetadata->amount, min( wc_get_price_decimals(), 2 ) ); // phpcs:ignore WordPress.NamingConventions
 
 			return $payload;
 		}
@@ -379,7 +379,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		if ( 1 === $subscriptions_in_cart ) {
 			$payload['recurringMetadata']['amount'] = array(
-				'amount'       => number_format( $recurring_total, 2 ),
+				'amount'       => number_format( $recurring_total, min( wc_get_price_decimals(), 2 ) ),
 				'currencyCode' => wc_apa_get_order_prop( $order, 'order_currency' ),
 			);
 		}
@@ -388,7 +388,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$payload['paymentDetails']['chargeAmount']['amount'] = number_format( $recurring_total, 2 );
+			$payload['paymentDetails']['chargeAmount']['amount'] = number_format( $recurring_total, min( wc_get_price_decimals(), 2 ) );
 		}
 
 		return $payload;
@@ -425,7 +425,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		$recurring_total = wc_format_decimal( $recurring_total, '' );
 
-		$payload['chargeAmount']['amount'] = number_format( $recurring_total, 2 );
+		$payload['chargeAmount']['amount'] = number_format( $recurring_total, min( wc_get_price_decimals(), 2 ) );
 
 		return $payload;
 	}
@@ -544,7 +544,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => number_format( $amount_to_charge, 2 ),
+					'amount'       => number_format( $amount_to_charge, min( wc_get_price_decimals(), 2 ) ),
 					'currencyCode' => $currency,
 				),
 			)

--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -295,13 +295,10 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			);
 
 			if ( 1 === $subscriptions_in_cart ) {
-				$currency_code = get_woocommerce_currency();
-				$demicals      = 'JPY' === $currency_code ? 0 : 2;
-
 				$first_recurring                        = reset( WC()->cart->recurring_carts );
 				$payload['recurringMetadata']['amount'] = array(
-					'amount'       => number_format( $first_recurring->get_total( 'edit' ), $demicals ),
-					'currencyCode' => $currency_code,
+					'amount'       => number_format( $first_recurring->get_total( 'edit' ), 2 ),
+					'currencyCode' => get_woocommerce_currency(),
 				);
 			}
 		} elseif ( $cart_contains_renewal || $change_payment_for_subscription ) {
@@ -323,14 +320,11 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 			$payload['chargePermissionType'] = 'Recurring';
 
-			$currency_code = wc_apa_get_order_prop( $subscription, 'order_currency' );
-			$demicals      = 'JPY' === $currency_code ? 0 : 2;
-
 			$payload['recurringMetadata'] = array(
 				'frequency' => $this->parse_interval_to_apa_frequency( $subscription->get_billing_period( 'edit' ), $subscription->get_billing_interval( 'edit' ) ),
 				'amount'    => array(
-					'amount'       => number_format( $subscription->get_total(), $demicals ),
-					'currencyCode' => $currency_code,
+					'amount'       => number_format( $subscription->get_total(), 2 ),
+					'currencyCode' => wc_apa_get_order_prop( $subscription, 'order_currency' ),
 				),
 			);
 		}
@@ -353,10 +347,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$currency_code = ! empty( $payload['paymentDetails']['currencyCode'] ) ? $payload['paymentDetails']['currencyCode'] : wc_apa_get_order_prop( $order, 'order_currency' );
-			$demicals      = 'JPY' === $currency_code ? 0 : 2;
-
-			$payload['paymentDetails']['chargeAmount'] = number_format( $checkout_session->recurringMetadata->amount, $demicals ); // phpcs:ignore WordPress.NamingConventions
+			$payload['paymentDetails']['chargeAmount'] = number_format( $checkout_session->recurringMetadata->amount, 2 ); // phpcs:ignore WordPress.NamingConventions
 
 			return $payload;
 		}
@@ -387,11 +378,9 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 		$recurring_total = wc_format_decimal( $recurring_total, '' );
 
 		if ( 1 === $subscriptions_in_cart ) {
-			$currency_code = wc_apa_get_order_prop( $order, 'order_currency' );
-			$demicals      = 'JPY' === $currency_code ? 0 : 2;
 			$payload['recurringMetadata']['amount'] = array(
-				'amount'       => number_format( $recurring_total, $demicals ),
-				'currencyCode' => $currency_code,
+				'amount'       => number_format( $recurring_total, 2 ),
+				'currencyCode' => wc_apa_get_order_prop( $order, 'order_currency' ),
 			);
 		}
 
@@ -399,10 +388,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$currency_code = ! empty( $payload['paymentDetails']['currencyCode'] ) ? $payload['paymentDetails']['currencyCode'] : wc_apa_get_order_prop( $order, 'order_currency' );
-			$demicals      = 'JPY' === $currency_code ? 0 : 2;
-
-			$payload['paymentDetails']['chargeAmount']['amount'] = number_format( $recurring_total, $demicals );
+			$payload['paymentDetails']['chargeAmount']['amount'] = number_format( $recurring_total, 2 );
 		}
 
 		return $payload;
@@ -439,10 +425,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		$recurring_total = wc_format_decimal( $recurring_total, '' );
 
-		$currency_code = ! empty( $payload['paymentDetails']['currencyCode'] ) ? $payload['paymentDetails']['currencyCode'] : get_woocommerce_currency();
-		$demicals      = 'JPY' === $currency_code ? 0 : 2;
-
-		$payload['chargeAmount']['amount'] = number_format( $recurring_total, $demicals );
+		$payload['chargeAmount']['amount'] = number_format( $recurring_total, 2 );
 
 		return $payload;
 	}
@@ -553,7 +536,6 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 		}
 
 		$currency = wc_apa_get_order_prop( $order, 'order_currency' );
-		$demicals = 'JPY' === $currency ? 0 : 2;
 
 		$response = WC_Amazon_Payments_Advanced_API::create_charge(
 			$charge_permission_id,
@@ -562,7 +544,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => number_format( $amount_to_charge, $demicals ),
+					'amount'       => number_format( $amount_to_charge, 2 ),
 					'currencyCode' => $currency,
 				),
 			)

--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -297,7 +297,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			if ( 1 === $subscriptions_in_cart ) {
 				$first_recurring                        = reset( WC()->cart->recurring_carts );
 				$payload['recurringMetadata']['amount'] = array(
-					'amount'       => number_format( $first_recurring->get_total( 'edit' ), min( wc_get_price_decimals(), 2 ) ),
+					'amount'       => WC_Amazon_Payments_Advanced::format_amount( $first_recurring->get_total( 'edit' ) ),
 					'currencyCode' => get_woocommerce_currency(),
 				);
 			}
@@ -323,7 +323,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['recurringMetadata'] = array(
 				'frequency' => $this->parse_interval_to_apa_frequency( $subscription->get_billing_period( 'edit' ), $subscription->get_billing_interval( 'edit' ) ),
 				'amount'    => array(
-					'amount'       => number_format( $subscription->get_total(), min( wc_get_price_decimals(), 2 ) ),
+					'amount'       => WC_Amazon_Payments_Advanced::format_amount( $subscription->get_total() ),
 					'currencyCode' => wc_apa_get_order_prop( $subscription, 'order_currency' ),
 				),
 			);
@@ -347,7 +347,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$payload['paymentDetails']['chargeAmount'] = number_format( $checkout_session->recurringMetadata->amount, min( wc_get_price_decimals(), 2 ) ); // phpcs:ignore WordPress.NamingConventions
+			$payload['paymentDetails']['chargeAmount'] = WC_Amazon_Payments_Advanced::format_amount( $checkout_session->recurringMetadata->amount ); // phpcs:ignore WordPress.NamingConventions
 
 			return $payload;
 		}
@@ -379,7 +379,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		if ( 1 === $subscriptions_in_cart ) {
 			$payload['recurringMetadata']['amount'] = array(
-				'amount'       => number_format( $recurring_total, min( wc_get_price_decimals(), 2 ) ),
+				'amount'       => WC_Amazon_Payments_Advanced::format_amount( $recurring_total ),
 				'currencyCode' => wc_apa_get_order_prop( $order, 'order_currency' ),
 			);
 		}
@@ -388,7 +388,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['paymentIntent'] = 'Confirm';
 			unset( $payload['paymentDetails']['canHandlePendingAuthorization'] );
 
-			$payload['paymentDetails']['chargeAmount']['amount'] = number_format( $recurring_total, min( wc_get_price_decimals(), 2 ) );
+			$payload['paymentDetails']['chargeAmount']['amount'] = WC_Amazon_Payments_Advanced::format_amount( $recurring_total );
 		}
 
 		return $payload;
@@ -425,7 +425,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		$recurring_total = wc_format_decimal( $recurring_total, '' );
 
-		$payload['chargeAmount']['amount'] = number_format( $recurring_total, min( wc_get_price_decimals(), 2 ) );
+		$payload['chargeAmount']['amount'] = WC_Amazon_Payments_Advanced::format_amount( $recurring_total );
 
 		return $payload;
 	}
@@ -544,7 +544,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => number_format( $amount_to_charge, min( wc_get_price_decimals(), 2 ) ),
+					'amount'       => WC_Amazon_Payments_Advanced::format_amount( $amount_to_charge ),
 					'currencyCode' => $currency,
 				),
 			)

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1174,7 +1174,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			 * }
 			 */
 
-			$order_total = number_format( $order->get_total(), min( wc_get_price_decimals(), 2 ) );
+			$order_total = WC_Amazon_Payments_Advanced::format_amount( $order->get_total() );
 			$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
 
 			wc_apa()->log( "Info: Beginning processing of payment for order {$order_id} for the amount of {$order_total} {$currency}. Checkout Session ID: {$checkout_session_id}." );
@@ -1264,7 +1264,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$order = wc_get_order( $order_id );
 
-		$order_total = number_format( $order->get_total(), min( wc_get_price_decimals(), 2 ) );
+		$order_total = WC_Amazon_Payments_Advanced::format_amount( $order->get_total() );
 		$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
 
 		wc_apa()->log( "Completing checkout session data for #{$order_id}." );
@@ -2135,7 +2135,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => number_format( $order->get_total(), min( wc_get_price_decimals(), 2 ) ),
+					'amount'       => WC_Amazon_Payments_Advanced::format_amount( $order->get_total() ),
 					'currencyCode' => $currency,
 				),
 			)

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1174,7 +1174,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			 * }
 			 */
 
-			$order_total = number_format( $order->get_total(), 2 );
+			$order_total = number_format( $order->get_total(), min( wc_get_price_decimals(), 2 ) );
 			$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
 
 			wc_apa()->log( "Info: Beginning processing of payment for order {$order_id} for the amount of {$order_total} {$currency}. Checkout Session ID: {$checkout_session_id}." );
@@ -1264,7 +1264,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$order = wc_get_order( $order_id );
 
-		$order_total = number_format( $order->get_total(), 2 );
+		$order_total = number_format( $order->get_total(), min( wc_get_price_decimals(), 2 ) );
 		$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
 
 		wc_apa()->log( "Completing checkout session data for #{$order_id}." );
@@ -2135,7 +2135,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => number_format( $order->get_total(), 2 ),
+					'amount'       => number_format( $order->get_total(), min( wc_get_price_decimals(), 2 ) ),
 					'currencyCode' => $currency,
 				),
 			)

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1174,9 +1174,8 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			 * }
 			 */
 
+			$order_total = number_format( $order->get_total(), 2 );
 			$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
-			$demicals    = 'JPY' === $currency ? 0 : 2;
-			$order_total = number_format( $order->get_total(), $demicals );
 
 			wc_apa()->log( "Info: Beginning processing of payment for order {$order_id} for the amount of {$order_total} {$currency}. Checkout Session ID: {$checkout_session_id}." );
 
@@ -1265,9 +1264,8 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$order = wc_get_order( $order_id );
 
+		$order_total = number_format( $order->get_total(), 2 );
 		$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
-		$demicals    = 'JPY' === $currency ? 0 : 2;
-		$order_total = number_format( $order->get_total(), $demicals );
 
 		wc_apa()->log( "Completing checkout session data for #{$order_id}." );
 
@@ -2129,7 +2127,6 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		}
 
 		$currency = wc_apa_get_order_prop( $order, 'order_currency' );
-		$demicals = 'JPY' === $currency ? 0 : 2;
 
 		$charge = WC_Amazon_Payments_Advanced_API::create_charge(
 			$id,
@@ -2138,7 +2135,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => number_format( $order->get_total(), $demicals ),
+					'amount'       => number_format( $order->get_total(), 2 ),
 					'currencyCode' => $currency,
 				),
 			)

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1174,8 +1174,9 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			 * }
 			 */
 
-			$order_total = number_format( $order->get_total(), 2 );
 			$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
+			$demicals    = 'JPY' === $currency ? 0 : 2;
+			$order_total = number_format( $order->get_total(), $demicals );
 
 			wc_apa()->log( "Info: Beginning processing of payment for order {$order_id} for the amount of {$order_total} {$currency}. Checkout Session ID: {$checkout_session_id}." );
 
@@ -1264,8 +1265,9 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$order = wc_get_order( $order_id );
 
-		$order_total = number_format( $order->get_total(), 2 );
 		$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
+		$demicals    = 'JPY' === $currency ? 0 : 2;
+		$order_total = number_format( $order->get_total(), $demicals );
 
 		wc_apa()->log( "Completing checkout session data for #{$order_id}." );
 
@@ -2127,6 +2129,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		}
 
 		$currency = wc_apa_get_order_prop( $order, 'order_currency' );
+		$demicals = 'JPY' === $currency ? 0 : 2;
 
 		$charge = WC_Amazon_Payments_Advanced_API::create_charge(
 			$id,
@@ -2135,7 +2138,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
 				'chargeAmount'                  => array(
-					'amount'       => number_format( $order->get_total(), 2 ),
+					'amount'       => number_format( $order->get_total(), $demicals ),
 					'currencyCode' => $currency,
 				),
 			)

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -273,6 +273,22 @@ class WC_Amazon_Payments_Advanced {
 	}
 
 	/**
+	 * Helper method to format a number before sending over to Amazon.
+	 *
+	 * @param string|float|int $num           Amount to format.
+	 * @param null|int         $decimals      The amount of decimals the formatted number should have.
+	 * @param string           $decimals_sep  The separator of the decimals.
+	 * @param string           $thousands_sep The separator of thousands.
+	 * @return string
+	 */
+	public static function format_amount( $num, $decimals = null, $decimals_sep = '.', $thousands_sep = '' ) {
+		/* Amazon won't accept any decimals more than 2. */
+		$decimals = $decimals > 2 ? null : $decimals;
+		$decimals = $decimals ? $decimals : min( wc_get_price_decimals(), 2 );
+		return number_format( $num, $decimals, $decimals_sep, $thousands_sep );
+	}
+
+	/**
 	 * Helper method to get order Version.
 	 *
 	 * @param int     $order_id Order ID.


### PR DESCRIPTION
Fixes [woo#148](https://github.com/woocommerce/woocommerce-gateway-amazon-pay/issues/148)

Before calling number_format, determine the currency and if its JPY format it with 0 demicals, otherwise 2.