### PR TITLE
Adds support for Amazon Pay as a traditional WooCommerce Gateway

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,4 +1,5 @@
-#pay_with_amazon {
+#pay_with_amazon,
+#classic_pay_with_amazon {
 	margin: 0px auto;
 	max-width: 100%;
 	line-height: 1em;
@@ -6,7 +7,8 @@
 	border: 0;
 	text-align: right;
 }
-#pay_with_amazon img {
+#pay_with_amazon img,
+#classic_pay_with_amazon img {
 	width: auto !important;
 	vertical-align: middle;
 	cursor: pointer;
@@ -22,7 +24,8 @@
 	min-height: 300px;
 	margin: 0 auto !important;
 }
-.woocommerce-info #pay_with_amazon {
+.woocommerce-info #pay_with_amazon,
+.woocommerce-info #classic_pay_with_amazon {
 	float: right;
 }
 #amazon_customer_details.wc-amazon-payments-advanced-populated
@@ -46,7 +49,8 @@
 	margin-right: 10px;
 	margin-bottom: 10px;
 }
-#payment .payment_methods li #pay_with_amazon img {
+#payment .payment_methods li #pay_with_amazon img,
+#payment .payment_methods li #classic_pay_with_amazon img {
 	max-height: 100%;
 }
 form.checkout .hidden {
@@ -85,15 +89,17 @@ span.wc-apa-amazon-logo {
 	margin-bottom: 1.618em;
 }
 
-
 .woocommerce-order-pay {
-	.wc_apa_login_again_text + #pay_with_amazon {
+	.wc_apa_login_again_text + #pay_with_amazon,
+	.wc_apa_login_again_text + #classic_pay_with_amazon {
 		margin-top: 1em;
 	}
 	#order_review {
 		#payment {
 			.payment_box.payment_method_amazon_payments_advanced {
-				#payment_method_widget, #shipping_address_widget, #billing_address_widget {
+				#payment_method_widget,
+				#shipping_address_widget,
+				#billing_address_widget {
 					margin-bottom: 0;
 					& + #payment_method_widget,
 					& + #shipping_address_widget,
@@ -109,8 +115,11 @@ span.wc-apa-amazon-logo {
 	}
 }
 
-.wc-apa-button-separator { 
+.wc-apa-button-separator {
 	margin: 1.5em 0;
 	text-align: center;
+	display: none;
+}
+#classic_pay_with_amazon {
 	display: none;
 }

--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -150,7 +150,7 @@
 		}
 
 		function isAmazonClassic() {
-			return ! $( '#amazon-logout' ).length && ( 'amazon_payments_advanced' === $( 'input[name=payment_method]:checked' ).val() );
+			return ! $( '.wc-apa-widget-change' ).length && ( 'amazon_payments_advanced' === $( 'input[name=payment_method]:checked' ).val() );
 		}
 
 		function getButtonSettings( buttonSettingsFlag ) {

--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -114,6 +114,7 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 		$default  = array(
 			'enabled'                         => 'yes',
 			'title'                           => __( 'Amazon Pay', 'woocommerce-gateway-amazon-payments-advanced' ),
+			'description'                     => __( 'Complete your payment using Amazon Pay!', 'woocommerce-gateway-amazon-payments-advanced' ),
 			'merchant_id'                     => '',
 			'store_id'                        => '',
 			'public_key_id'                   => '',

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -389,6 +389,12 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 
 	}
 
+	/**
+	 * Create classic checkout session parameters for button.
+	 *
+	 * @param string $redirect_url Redirect URL on success.
+	 * @return array
+	 */
 	public static function create_checkout_session_classic_params( $redirect_url = null ) {
 
 		$settings = self::get_settings();
@@ -448,6 +454,13 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 		);
 	}
 
+	/**
+	 * Get classic create checkout session config to send to Amazon.
+	 *
+	 * @param array  $payload      The payload that will be used to create a checkout session.
+	 * @param string $redirect_url Redirect URL on success.
+	 * @return array
+	 */
 	public static function get_create_checkout_classic_session_config( $payload, $redirect_url = null ) {
 		$settings = self::get_settings();
 		$client   = self::get_client();
@@ -457,16 +470,6 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 			'payloadJSON' => $payload,
 			'signature'   => $signature,
 		);
-	}
-
-	public static function create_checkout_config( $config ) {
-		$client = self::get_client();
-		$headers = array(
-			'x-amz-pay-idempotency-key' => self::generate_uuid(),
-			// 'x-amz-pay-date'            => gmdate( 'Ymd' ) . 'T' . gmdate( 'His' ) . 'Z',
-			// 'authorization'             => $config['signature'],
-		);
-		return json_decode( $client->createCheckoutSession( $config['payloadJSON'], $headers )['response'] );
 	}
 
 	/**

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -473,6 +473,14 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 				'type'        => 'checkbox',
 				'default'     => 'no',
 			),
+			'enable_classic_gateway'        => array(
+				'title'       => __( 'Classic Gateway', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'label'       => __( 'Enable Amazon Pay as a classic Gateway Option', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'description' => __( 'This will enable Amazon Pay to also appear along other Gateway Options.', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'desc_tip'    => true,
+				'type'        => 'checkbox',
+				'default'     => 'yes',
+			),
 		);
 
 		if ( $this->has_other_gateways_enabled() ) {
@@ -857,6 +865,27 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 		}
 	}
 
+	public function classic_integration_button( $echo = true, $elem = 'div' ) {
+		if ( empty( $this->settings['enable_classic_gateway'] ) || 'yes' === $this->settings['enable_classic_gateway'] ) {
+			$subscriptions_installed = class_exists( 'WC_Subscriptions_Order' ) && function_exists( 'wcs_create_renewal_order' );
+			$subscriptions_enabled   = empty( $this->settings['subscriptions_enabled'] ) || 'yes' === $this->settings['subscriptions_enabled'];
+			$cart_contains_sub       = class_exists( 'WC_Subscriptions_Cart' ) ? WC_Subscriptions_Cart::cart_contains_subscription() : false;
+
+			if ( $subscriptions_installed && ! $subscriptions_enabled && $cart_contains_sub ) {
+				return;
+			}
+
+			$button_placeholder = '<' . $elem . ' id="classic_pay_with_amazon"></' . $elem . '>';
+
+			if ( false === $echo ) {
+				return $button_placeholder;
+			} else {
+				echo $button_placeholder;
+				return true;
+			}
+		}
+	}
+
 	/**
 	 * Remove amazon gateway.
 	 *
@@ -865,8 +894,10 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	 * @return array
 	 */
 	public function remove_amazon_gateway( $gateways ) {
-		if ( isset( $gateways[ $this->id ] ) ) {
-			unset( $gateways[ $this->id ] );
+		if ( ! empty( $this->settings['enable_classic_gateway'] ) && 'no' === $this->settings['enable_classic_gateway'] ) {
+			if ( isset( $gateways[ $this->id ] ) ) {
+				unset( $gateways[ $this->id ] );
+			}
 		}
 
 		return $gateways;

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -880,6 +880,15 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 		}
 	}
 
+	/**
+	 * Classic Checkout button
+	 *
+	 * Triggered from 'woocommerce_after_checkout_form' and 'woocommerce_pay_order_after_submit'.
+	 *
+	 * @param bool   $echo Wether to echo or not.
+	 * @param string $elem HTML tag to render.
+	 * @return bool|string|void
+	 */
 	public function classic_integration_button( $echo = true, $elem = 'div' ) {
 		if ( empty( $this->settings['enable_classic_gateway'] ) || 'yes' === $this->settings['enable_classic_gateway'] ) {
 			$subscriptions_installed = class_exists( 'WC_Subscriptions_Order' ) && function_exists( 'wcs_create_renewal_order' );

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -238,6 +238,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 		$settings = WC_Amazon_Payments_Advanced_API::get_settings();
 
 		$this->title                   = $settings['title'];
+		$this->description             = $settings['description'];
 		$this->payment_region          = $settings['payment_region'];
 		$this->merchant_id             = $settings['merchant_id'];
 		$this->store_id                = $settings['store_id'];
@@ -309,6 +310,20 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 				'type'        => 'checkbox',
 				'description' => '',
 				'default'     => 'yes',
+			),
+			'title'                         => array(
+				'title'       => __( 'Title', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'type'        => 'text',
+				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'default'     => __( 'Amazon Pay', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'desc_tip'    => true,
+			),
+			'description'                   => array(
+				'title'       => __( 'Description', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'type'        => 'textarea',
+				'description' => __( 'Payment method description that the customer will see on your checkout.', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'default'     => __( 'Complete your payment using Amazon Pay!', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'desc_tip'    => true,
 			),
 			'account_details'               => array(
 				'title'       => __( 'Amazon Pay Merchant account details', 'woocommerce-gateway-amazon-payments-advanced' ),

--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -356,22 +356,14 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 		if ( $doing_classic_payment ) {
 			if ( 'PayAndShip' === wc_apa()->get_gateway()->get_current_cart_action() ) {
 				$payload['addressDetails'] = array(
-					'name'          => $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name(),
-					'addressLine1'  => $order->get_shipping_address_1(),
-					'city'          => $order->get_shipping_city(),
-					'stateOrRegion' => $order->get_shipping_state(),
-					'postalCode'    => $order->get_shipping_postcode(),
+					'name'          => utf8_encode( $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name() ),
+					'addressLine1'  => utf8_encode( $order->get_shipping_address_1() ),
+					'city'          => utf8_encode( $order->get_shipping_city() ),
+					'stateOrRegion' => utf8_encode( $order->get_shipping_state() ),
+					'postalCode'    => utf8_encode( $order->get_shipping_postcode() ),
 					'countryCode'   => $order->get_shipping_country( 'edit' ),
-					'phoneNumber'   => $order->get_billing_phone(),
+					'phoneNumber'   => utf8_encode( $order->get_billing_phone() ),
 				);
-				$payload['addressDetails'] = array_map( function( $v ) {
-					if ( function_exists( 'mb_check_encoding' ) ) {
-						if ( ! mb_check_encoding( $v, 'UTF-8' ) ) {
-							$v = rawurlencode( $v );
-						}
-					}
-					return $v;
-				}, $payload['addressDetails'] );
 			}
 		}
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -140,9 +140,8 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		add_action( 'woocommerce_after_checkout_form', array( $this, 'classic_integration_button' ) );
 
 		// Pay Order
-		add_action( 'woocommerce_receipt_' . $this->id, array( $this, 'classic_integration_button' ) );
 		add_action( 'woocommerce_pay_order_after_submit', array( $this, 'classic_integration_button' ) );
-
+		add_action( 'woocommerce_pay_order_after_submit', array( $this, 'checkout_button' ) );
 		if ( $this->doing_ajax() ) {
 			add_action( 'woocommerce_before_cart_totals', array( $this, 'update_js' ) );
 		}

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2380,13 +2380,8 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	}
 
 	public function remove_amazon_gateway_order_pay() {
-		if ( ! empty( $this->settings['enable_classic_gateway'] ) && 'no' === $this->settings['enable_classic_gateway'] && ! $this->is_logged_in() ) {
-			add_filter( 'woocommerce_available_payment_gateways', function( $gateways ) {
-				if ( isset( $gateways[ $this->id ] ) ) {
-					unset( $gateways[ $this->id ] );
-				}
-				return $gateways;
-			} );
+		if ( ! $this->is_logged_in() ) {
+			add_filter( 'woocommerce_available_payment_gateways', 'remove_amazon_gateway' );
 		}
 	}
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -141,7 +141,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		// Pay Order
 		add_action( 'woocommerce_pay_order_after_submit', array( $this, 'classic_integration_button' ) );
-		add_action( 'woocommerce_pay_order_after_submit', array( $this, 'checkout_button' ) );
+		add_action( 'woocommerce_pay_order_after_submit', array( $this, 'maybe_checkout_button' ) );
 		if ( $this->doing_ajax() ) {
 			add_action( 'woocommerce_before_cart_totals', array( $this, 'update_js' ) );
 		}
@@ -696,6 +696,13 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		return $this->checkout_session;
 	}
 
+	public function maybe_checkout_button( $echo = true, $elem = 'div' ) {
+		if ( ! $this->is_logged_in() ) {
+			$this->display_amazon_pay_button_separator_html();
+			$this->checkout_button( $echo, $elem );
+		}
+	}
+
 	/**
 	 * Check wether the user is logged in to amazon or not.
 	 *
@@ -1194,6 +1201,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 			$order_total = WC_Amazon_Payments_Advanced::format_amount( $order->get_total() );
 			$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
+			$payload     = array();
 
 			if ( $doing_classic_payment ) {
 				$payload = WC_Amazon_Payments_Advanced_API::create_checkout_session_classic_params( $order->get_checkout_payment_url() );

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-abstract.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-abstract.php
@@ -56,6 +56,7 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 
 		add_filter( 'woocommerce_amazon_pa_is_checkout_session_still_valid', array( $this, 'is_checkout_session_still_valid' ), 10, 2 );
 		add_filter( 'woocommerce_amazon_pa_create_checkout_session_params', array( $this, 'set_presentment_currency' ) );
+		add_filter( 'woocommerce_amazon_pa_create_checkout_session_classic_params', array( $this, 'set_presentment_currency' ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Introduces Amazon Pay as a traditional WooCommerce Gateway based on an option in the plugin settings, which we will be referring to as 'classic'.

Key differences when using the classic option is we need to provide to Amazon the shipping details of the order if the order needs shipping and the customer doesn't have the chance to review the order after being redirected to Amazon since he is going to complete his checkout process there and then he will return to merchant's site.

In the order-pay endpoint, we had to change where the already implemented checkout button was appearing in order to put the classic method in its place. Its still available, but now appearing in the same place as in the checkout page.

Technical Details

We have implemented the integration named "Additional payment button" by Amazon.
@see https://developer.amazon.com/docs/amazon-pay-apb-checkout/additional-payment-button-overview.html

In the checkout endpoint, when Amazon classic is selected as the payment method. Gateway's process_payment method
returns a result object containing all the required params for the JS to create an Amazon button to initiate the payment, while also providing a redirect value to a HTML element of the same page that does not exists so that JS will have the chance to initiate the Amazon process. JS hooks on the 'checkout_place_order_success", creates the Amazon button hidden and then triggers a click on it for the process to be initiated. That way the flow appears to the end customer as a one-step process.

In the order-pay endpoint, when Amazon classic is selected as the payment method. We overwrite the form's default functionality to an AJAX request in our own endpoint in order to follow the same process as in the checkout endpoint.


### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Introduces Amazon Pay as a traditional WooCommerce Gateway.
> Add - 3 new options. For controlling the traditional appearance of Amazon Pay, gateway's title and description.
