### PR TITLE
Adds support for Amazon Pay in WooCommerce's mini cart

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,5 +1,6 @@
 #pay_with_amazon,
-#classic_pay_with_amazon {
+#classic_pay_with_amazon,
+#pay_with_amazon_cart {
 	margin: 0px auto;
 	max-width: 100%;
 	line-height: 1em;
@@ -8,7 +9,8 @@
 	text-align: right;
 }
 #pay_with_amazon img,
-#classic_pay_with_amazon img {
+#classic_pay_with_amazon img,
+#pay_with_amazon_cart img {
 	width: auto !important;
 	vertical-align: middle;
 	cursor: pointer;
@@ -25,7 +27,8 @@
 	margin: 0 auto !important;
 }
 .woocommerce-info #pay_with_amazon,
-.woocommerce-info #classic_pay_with_amazon {
+.woocommerce-info #classic_pay_with_amazon,
+.woocommerce-info #pay_with_amazon_cart {
 	float: right;
 }
 #amazon_customer_details.wc-amazon-payments-advanced-populated
@@ -50,7 +53,8 @@
 	margin-bottom: 10px;
 }
 #payment .payment_methods li #pay_with_amazon img,
-#payment .payment_methods li #classic_pay_with_amazon img {
+#payment .payment_methods li #classic_pay_with_amazon img,
+#payment .payment_methods li #pay_with_amazon_cart img {
 	max-height: 100%;
 }
 form.checkout .hidden {
@@ -91,7 +95,8 @@ span.wc-apa-amazon-logo {
 
 .woocommerce-order-pay {
 	.wc_apa_login_again_text + #pay_with_amazon,
-	.wc_apa_login_again_text + #classic_pay_with_amazon {
+	.wc_apa_login_again_text + #classic_pay_with_amazon,
+	.wc_apa_login_again_text + #pay_with_amazon_cart {
 		margin-top: 1em;
 	}
 	#order_review {

--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -70,15 +70,13 @@
 		} );
 
 		/* Handles Amazon Pay Button on Cart after a cart update. */
-		$( document.body ).on( 'wc_fragments_loaded', function( fragments, cartHash, clickedBtn ) {
-			var amzCartBtn = renderButton( '#pay_with_amazon_cart', 'cart' );
-			addCartBtnClickEvent( amzCartBtn );
+		$( document.body ).on( 'wc_fragments_loaded', function( event ) {
+			renderButton( '#pay_with_amazon_cart', 'cart' );
 		} );
 
 		/* Handles Amazon Pay Button on Cart during load. */
 		if ( $( '#pay_with_amazon_cart' ).length > 0 ) {
-			var amzCartBtn = renderButton( '#pay_with_amazon_cart', 'cart' );
-			addCartBtnClickEvent( amzCartBtn );
+			renderButton( '#pay_with_amazon_cart', 'cart' );
 		}
 
 		function submit_error( $elem, error_message ) {
@@ -96,7 +94,7 @@
 
 		function renderButton( btnId, buttonSettingsFlag ) {
 			btnId = btnId || button_id;
-			attemptRefreshData();
+			attemptRefreshData( buttonSettingsFlag );
 			if ( 0 === $( btnId ).length ) {
 				return;
 			}
@@ -143,8 +141,8 @@
 		$( document.body ).on( 'payment_method_selected', renderButton );
 		$( document.body ).on( 'updated_shipping_method', renderButton );
 
-		function attemptRefreshData() {
-			var dataCont = $( '#wc-apa-update-vals' );
+		function attemptRefreshData( flag ) {
+			var dataCont = 'cart' === flag ? $( '#wc-apa-update-vals-cart' ) : $( '#wc-apa-update-vals' );
 			if ( ! dataCont.length ) {
 				return;
 			}
@@ -185,38 +183,16 @@
 				// customize the buyer experience
 				placement: amazon_payments_advanced.placement,
 				buttonColor: amazon_payments_advanced.button_color,
-				checkoutLanguage: amazon_payments_advanced.button_language !== '' ? amazon_payments_advanced.button_language.replace( '-', '_' ) : undefined
+				checkoutLanguage: amazon_payments_advanced.button_language !== '' ? amazon_payments_advanced.button_language.replace( '-', '_' ) : undefined,
+				productType: amazon_payments_advanced.action
 			};
 			if ( 'classic' === buttonSettingsFlag && null !== amzCreateCheckoutConfig ) {
 				obj.productType = 'undefined' !== typeof amzCreateCheckoutConfig.payloadJSON.addressDetails ? 'PayAndShip' : 'PayOnly';
 				amzCreateCheckoutConfig.payloadJSON = JSON.stringify( amzCreateCheckoutConfig.payloadJSON );
-			} else if ( 'cart' !== buttonSettingsFlag ) {
+			} else {
 				obj.createCheckoutSessionConfig = amazon_payments_advanced.create_checkout_session_config;
-				obj.productType = amazon_payments_advanced.action;
 			}
 			return obj;
-		}
-
-		function addCartBtnClickEvent( cartBtn ) {
-			cartBtn.onClick( function() {
-				$.ajax(
-					{
-						url: amazon_payments_advanced.ajax_url,
-						data: 'action=' + amazon_payments_advanced.fresh_params.action + '&_fresh_params_nonce=' + amazon_payments_advanced.fresh_params.nonce,
-						success: function( result ) {
-							if ( result.success && result.data ) {
-								cartBtn.initCheckout( {
-									createCheckoutSessionConfig: result.data.create_checkout_session_config,
-									productType: result.data.action
-								} );
-							}
-						},
-						error:	function( jqXHR, textStatus, errorThrown ) {
-							console.error( errorThrown );
-						}
-					}
-				);
-			} );
 		}
 
 		function toggleDetailsVisibility( detailsListName ) {

--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -14,6 +14,12 @@
 			}
 			return true;
 		} );
+		$( document.body ).on( 'added_to_cart removed_from_cart', function( fragments, cartHash, clickedBtn ) {
+			renderButton( '#pay_with_amazon_cart' );
+		} );
+		if ( $( '#pay_with_amazon_cart' ).length > 0 ) {
+			renderButton( '#pay_with_amazon_cart' );
+		}
 		$( 'form#order_review' ).on( 'submit', function( e ) {
 			if ( isAmazonClassic() ) {
 				e.preventDefault();

--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -138,6 +138,7 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 			'hide_button_mode'                => 'no',
 			'amazon_keys_setup_and_validated' => '0',
 			'subscriptions_enabled'           => 'yes',
+			'mini_cart_button'                => 'no',
 		);
 
 		$settings = apply_filters( 'woocommerce_amazon_pa_settings', array_merge( $default, $settings ) );

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -496,6 +496,14 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 				'type'        => 'checkbox',
 				'default'     => 'yes',
 			),
+			'mini_cart_button'              => array(
+				'title'       => __( 'Amazon Pay on mini cart', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'label'       => __( 'Enable Amazon Pay on mini cart', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'description' => __( 'This will only work if you are using WooCommerce\'s mini cart. If you enable it and the Amazon Pay does not show please disable since it also enables loading of required assets globally in your frontend.', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'desc_tip'    => true,
+				'type'        => 'checkbox',
+				'default'     => 'no',
+			),
 		);
 
 		if ( $this->has_other_gateways_enabled() ) {
@@ -861,7 +869,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	 * @param  string $elem HTML tag to render.
 	 * @return bool|string|void
 	 */
-	public function checkout_button( $echo = true, $elem = 'div' ) {
+	public function checkout_button( $echo = true, $elem = 'div', $id = 'pay_with_amazon' ) {
 		$subscriptions_installed = class_exists( 'WC_Subscriptions_Order' ) && function_exists( 'wcs_create_renewal_order' );
 		$subscriptions_enabled   = empty( $this->settings['subscriptions_enabled'] ) || 'yes' === $this->settings['subscriptions_enabled'];
 		$cart_contains_sub       = class_exists( 'WC_Subscriptions_Cart' ) ? WC_Subscriptions_Cart::cart_contains_subscription() : false;
@@ -870,7 +878,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 			return;
 		}
 
-		$button_placeholder = '<' . $elem . ' id="pay_with_amazon"></' . $elem . '>';
+		$button_placeholder = '<' . $elem . ' id="' . esc_attr( $id ) . '"></' . $elem . '>';
 
 		if ( false === $echo ) {
 			return $button_placeholder;


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Adds support for the Amazon Pay button in the WooCommerce's mini cart.

This PR should be reviewed and merged after #145.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Support for Amazon Pay in WooCommerce's mini cart.
