### PR TITLE
Adds support for Amazon Pay in Product Pages

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,5 +1,6 @@
 #pay_with_amazon,
-#pay_with_amazon_cart {
+#pay_with_amazon_cart,
+#pay_with_amazon_product {
 	margin: 0px auto;
 	max-width: 100%;
 	line-height: 1em;
@@ -8,7 +9,8 @@
 	text-align: right;
 }
 #pay_with_amazon img,
-#pay_with_amazon_cart img {
+#pay_with_amazon_cart img,
+#pay_with_amazon_product img {
 	width: auto !important;
 	vertical-align: middle;
 	cursor: pointer;
@@ -25,7 +27,8 @@
 	margin: 0 auto !important;
 }
 .woocommerce-info #pay_with_amazon,
-.woocommerce-info #pay_with_amazon_cart {
+.woocommerce-info #pay_with_amazon_cart,
+.woocommerce-info #pay_with_amazon_product {
 	float: right;
 }
 #amazon_customer_details.wc-amazon-payments-advanced-populated
@@ -50,7 +53,8 @@
 	margin-bottom: 10px;
 }
 #payment .payment_methods li #pay_with_amazon img,
-#payment .payment_methods li #pay_with_amazon_cart img {
+#payment .payment_methods li #pay_with_amazon_cart img,
+#payment .payment_methods li #pay_with_amazon_product img {
 	max-height: 100%;
 }
 form.checkout .hidden {
@@ -91,7 +95,8 @@ span.wc-apa-amazon-logo {
 
 .woocommerce-order-pay {
 	.wc_apa_login_again_text + #pay_with_amazon,
-	.wc_apa_login_again_text + #pay_with_amazon_cart {
+	.wc_apa_login_again_text + #pay_with_amazon_cart,
+	.wc_apa_login_again_text + #pay_with_amazon_product {
 		margin-top: 1em;
 	}
 	#order_review {
@@ -120,6 +125,11 @@ span.wc-apa-amazon-logo {
 	text-align: center;
 	display: none;
 }
+
 #classic_pay_with_amazon {
 	display: none;
+}
+
+#pay_with_amazon_product {
+	margin-bottom: .7em;
 }

--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -27,6 +27,7 @@
 				amazonProductBtn.onClick( function() {
 					if ( ! $( '.single_add_to_cart_button' ).hasClass( 'disabled' ) ) {
 						var pid = $( 'button[type="submit"][name="add-to-cart"]' ).attr( 'value' );
+						pid = pid || $( 'input[type="hidden"][name="product_id"]' ).val();
 						var qnt = $( 'input[type="number"][name="quantity"]' ).val();
 						var vid = $( 'input[type="hidden"][name="variation_id"]' ).length > 0 ? $( 'input[type="hidden"][name="variation_id"]' ).val() : false;
 						var qrs = '&pid=' + pid + '&qnt=' + qnt + ( vid ? '&vid=' + vid : '' );

--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -80,10 +80,15 @@
 		}
 
 		/* Handles Amazon Pay Button on Product Pages. */
-		if ( $( '#pay_with_amazon_product' ).length > 0 ) {
+
+		var amzPrdBtnCont = $( '#pay_with_amazon_product' );
+
+		if ( amzPrdBtnCont.length > 0 ) {
+
 			var amazonProductBtn = renderButton( '#pay_with_amazon_product', 'product' );
-			var amzPrdBtnCont = $( '#pay_with_amazon_product' );
+
 			if ( null !== amazonProductBtn ) {
+
 				amazonProductBtn.onClick( function() {
 					var singleAddToCart = $( '.single_add_to_cart_button' );
 					if ( singleAddToCart.hasClass( 'disabled' ) ) {

--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -84,31 +84,42 @@
 			var amazonProductBtn = renderButton( '#pay_with_amazon_product', 'product' );
 			if ( null !== amazonProductBtn ) {
 				amazonProductBtn.onClick( function() {
-					if ( ! $( '.single_add_to_cart_button' ).hasClass( 'disabled' ) ) {
-						var pid = $( 'button[type="submit"][name="add-to-cart"]' ).attr( 'value' );
-						pid = pid || $( 'input[type="hidden"][name="product_id"]' ).val();
-						var qnt = $( 'input[type="number"][name="quantity"]' ).val();
-						var vid = $( 'input[type="hidden"][name="variation_id"]' ).length > 0 ? $( 'input[type="hidden"][name="variation_id"]' ).val() : false;
-						var qrs = '&pid=' + pid + '&qnt=' + qnt + ( vid ? '&vid=' + vid : '' );
-						$.ajax(
-							{
-								url: amazon_payments_advanced.ajax_url,
-								type: 'get',
-								data: 'action=' + amazon_payments_advanced.change_cart_action + '&_change_carts_nonce=' + amazon_payments_advanced.change_cart_ajax_nonce + qrs,
-								async: false,
-								success: function( result ) {
-									if ( result.data.create_checkout_session_config ) {
-										amazonProductBtn.initCheckout( {
-											createCheckoutSessionConfig: result.data.create_checkout_session_config
-										} );
-									}
-								},
-								error:	function( jqXHR, textStatus, errorThrown ) {
-									console.error( errorThrown );
-								}
-							}
-						);
+					if ( $( '.single_add_to_cart_button' ).hasClass( 'disabled' ) ) {
+						$( '.single_add_to_cart_button' ).trigger( 'click' );
+						return;
 					}
+					var elemToBlock = $( '#pay_with_amazon_product' ).closest( 'div.summary' ).length > 0 ? $( '#pay_with_amazon_product' ).closest( 'div.summary' ) : false;
+					if ( elemToBlock ) {
+						block( elemToBlock );
+					}
+					var pid = $( 'button[type="submit"][name="add-to-cart"]' ).attr( 'value' );
+					pid = pid || $( 'input[type="hidden"][name="product_id"]' ).val();
+					var qnt = $( 'input[type="number"][name="quantity"]' ).val();
+					var vid = $( 'input[type="hidden"][name="variation_id"]' ).length > 0 ? $( 'input[type="hidden"][name="variation_id"]' ).val() : false;
+					var qrs = '&pid=' + pid + '&qnt=' + qnt + ( vid ? '&vid=' + vid : '' );
+					$.ajax(
+						{
+							url: amazon_payments_advanced.ajax_url,
+							type: 'get',
+							data: 'action=' + amazon_payments_advanced.change_cart_action + '&_change_carts_nonce=' + amazon_payments_advanced.change_cart_ajax_nonce + qrs,
+							success: function( result ) {
+								if ( elemToBlock ) {
+									unblock( elemToBlock );
+								}
+								if ( result.data.create_checkout_session_config ) {
+									amazonProductBtn.initCheckout( {
+										createCheckoutSessionConfig: result.data.create_checkout_session_config
+									} );
+								}
+							},
+							error:	function( jqXHR, textStatus, errorThrown ) {
+								if ( elemToBlock ) {
+									unblock( elemToBlock );
+								}
+								console.error( errorThrown );
+							}
+						}
+					);
 				} );
 			}
 		}

--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -139,6 +139,7 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 			'amazon_keys_setup_and_validated' => '0',
 			'subscriptions_enabled'           => 'yes',
 			'mini_cart_button'                => 'no',
+			'product_button'                  => 'no',
 		);
 
 		$settings = apply_filters( 'woocommerce_amazon_pa_settings', array_merge( $default, $settings ) );

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -504,6 +504,14 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 				'type'        => 'checkbox',
 				'default'     => 'no',
 			),
+			'product_button'                => array(
+				'title'       => __( 'Amazon Pay on product pages', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'label'       => __( 'Enable Amazon Pay on product pages', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'description' => __( 'This will enable the Amazon Pay button on the product pages next to the Add to Cart button.', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'desc_tip'    => true,
+				'type'        => 'checkbox',
+				'default'     => 'no',
+			),
 		);
 
 		if ( $this->has_other_gateways_enabled() ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -570,7 +570,6 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( ! empty( $this->settings['product_button'] ) && 'yes' === $this->settings['product_button'] ) {
 			$this->display_amazon_pay_button_separator_html();
 			$this->checkout_button( true, 'div', 'pay_with_amazon_product' );
-			$this->checkout_button( true, 'div', 'pay_with_amazon_product_real' );
 		}
 	}
 
@@ -2649,7 +2648,6 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 			$data = array(
 				'create_checkout_session_config' => $checkout_session_config,
-				'create_checkout_session_hash'   => wp_hash( $checkout_session_config['payloadJSON'] ),
 			);
 			wp_send_json_success( $data, 200 );
 		}

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2634,6 +2634,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				WC()->session->set( $session_key, WC()->session->get( 'amazon_pay_' . $session_key ) );
 				WC()->session->set( 'amazon_pay_' . $session_key, null );
 			}
+			WC()->session->save_data();
 			WC()->cart->get_cart_from_session();
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for the Amazon Pay button in Product Pages.

Technical details

When the amazon pay button located in the product page is clicked an AJAX request is taking place which saves the active cart
in WooCommerce's session, empties current cart and adds only the selected product and finally provides the JS with required parameters for amazon to initiate the new checkout session.

When the checkout session is completed, the cart that was stored gets restored.

This PR should be reviewed and merger after #146.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Support for Amazon Pay button on Product pages.
