### PR TITLE
Adds support for Alexa Delivery notifications

### DIFF
--- a/includes/class-wc-amazon-payments-adavanced-alexa-notifications-abstract.php
+++ b/includes/class-wc-amazon-payments-adavanced-alexa-notifications-abstract.php
@@ -10,21 +10,101 @@
  */
 abstract class WC_Amazon_Payments_Advanced_Alexa_Notifications_Abstract {
 
-    protected $action;
+	/**
+	 * Action on which we are hooking on.
+	 *
+	 * We are expecting action to provide as parameters the tracking number and
+	 * the order id of which we are to enable Alexa Delivery notifications.
+	 *
+	 * @var string
+	 */
+	protected $action;
 
-    protected $carrier;
+	/**
+	 * The carrier code through the shipping is being handled.
+	 *
+	 * Should be supported by Amazon API.
+	 * @see https://developer.amazon.com/docs/amazon-pay-checkout/setting-up-delivery-notifications.html
+	 *
+	 * For a list of supported carriers,
+	 * @see https://eps-eu-external-file-share.s3.eu-central-1.amazonaws.com/Alexa/Delivery+Notifications/amazon-pay-delivery-tracker-supported-carriers-v2.csv
+	 *
+	 * @var string
+	 */
+	protected $carrier;
 
-    public function __construct( string $action, string $carrier ) {
-        $this->action  = $action;
-        $this->carrier = $carrier;
+	/**
+	 * Constructor, which registers this instance's enable_alexa_notifications_for_carrier
+	 * to the $action provided.
+	 *
+	 * @param string $action
+	 * @param string $carrier
+	 */
+	public function __construct( string $action, string $carrier ) {
+		$this->action  = $action;
+		$this->carrier = $carrier;
 
-        if ( is_callable( $this->action ) ) {
-            add_action(
-                $this->action,
-                array( $this, 'enable_alexa_notifications_for_carrier' ),
-                apply_filters( 'apa_enable_alexa_notifications_for_carrier_priority_' . str_replace( ' ', '_', strtolower( $this->carrier ) ), 10 ),
-                apply_filters( 'apa_enable_alexa_notifications_for_carrier_accepted_args_' . str_replace( ' ', '_', strtolower( $this->carrier ) ), 2 )
-            );
-        }
-    }
+		add_action(
+			$this->action,
+			array( $this, 'enable_alexa_notifications_for_carrier' ),
+			apply_filters( 'apa_enable_alexa_notifications_for_carrier_priority_' . str_replace( ' ', '_', strtolower( $this->carrier ) ), 10 ),
+			apply_filters( 'apa_enable_alexa_notifications_for_carrier_accepted_args_' . str_replace( ' ', '_', strtolower( $this->carrier ) ), 2 )
+		);
+	}
+
+	/**
+	 * Enables Alexa Delivery notifications for an Order.
+	 *
+	 * For debug purposes you should enable logging for the Amazon Pay Gateway
+	 * and look the logs Under WooCommerce -> Status -> Logs while testing your
+	 * integration.
+	 *
+	 * @param mixed $tracking_number
+	 * @param string|int $order_id
+	 * @return void
+	 */
+	public function enable_alexa_notifications_for_carrier( $tracking_number, $order_id ) {
+		$handler = apply_filters( 'apa_alexa_notification_handler_' . str_replace( ' ', '_', strtolower( $this->carrier ) ), __METHOD__ );
+		if ( __METHOD__ !== $handler ) {
+			if ( is_callable( $handler ) ) {
+				return call_user_func_array( $handler, array( $tracking_number, $order_id ) );
+			}
+			if ( is_null( $handler ) ) {
+				return;
+			}
+		}
+		if ( ! empty( $tracking_number ) && ! empty( $order_id ) ) {
+			$order = wc_get_order( $order_id );
+			if ( ! is_a( $order, 'WC_Order' ) ) {
+				$charge_permission_id = apply_filters( 'apa_alexa_notification_charge_permission_id', $order->get_meta( 'amazon_charge_permission_id' ), $order, $this->carrier );
+				if ( 'amazon_payments_advanced' === $order->get_payment_method() && $charge_permission_id ) {
+					$payload = apply_filters(
+						'apa_alexa_notification_payload_' . str_replace( ' ', '_', strtolower( $this->carrier ) ),
+						array(
+							'chargePermissionId' => $charge_permission_id,
+							'deliveryDetails'    => array(
+								'trackingNumber' => $tracking_number,
+								'carrierCode'    => $this->carrier,
+							),
+						)
+					);
+					try {
+						if ( ! class_exists( 'WC_Amazon_Payments_Advanced_API' ) ) {
+							throw new Exception( 'Class WC_Amazon_Payments_Advanced_API does not exists!', 1001 );
+						}
+						$result = WC_Amazon_Payments_Advanced_API::trigger_alexa_notifications( $payload );
+						if ( ! empty( $result['status'] ) && 200 === $result['status'] ) {
+							// Success.
+							wc_apa()->log( 'Successfully enabled Alexa Delivery Notifications for order #' . $order_id . ' with charge permission id ' . $charge_permission_id . ' and got the below response', $result['response'] );
+						} else {
+							// Error.
+							wc_apa()->log( 'Failed to enable Alexa Delivery Notifications for order #' . $order_id . ' with charge permission id ' . $charge_permission_id . ' with status: ' . $result['status'] . ' and got the below response', $result['response'] );
+						}
+					} catch ( Exception $e ) {
+						wc_apa()->log( 'Exception occurred while trying to enable Alexa Delivery Notifications for order #' . $order_id . ' with charge permission id ' . $charge_permission_id . ' with code: ' . $e->getCode() . ' and message: ' . $e->getMessage() );
+					}
+				}
+			}
+		}
+	}
 }

--- a/includes/class-wc-amazon-payments-adavanced-alexa-notifications-abstract.php
+++ b/includes/class-wc-amazon-payments-adavanced-alexa-notifications-abstract.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Amazon Alexa Notifications abstract class.
+ *
+ * @package WC_Gateway_Amazon_Pay
+ */
+
+/**
+ * Amazon Alexa Notifications abstract class
+ */
+abstract class WC_Amazon_Payments_Advanced_Alexa_Notifications_Abstract {
+
+    protected $action;
+
+    protected $carrier;
+
+    public function __construct( string $action, string $carrier ) {
+        $this->action  = $action;
+        $this->carrier = $carrier;
+
+        if ( is_callable( $this->action ) ) {
+            add_action(
+                $this->action,
+                array( $this, 'enable_alexa_notifications_for_carrier' ),
+                apply_filters( 'apa_enable_alexa_notifications_for_carrier_priority_' . str_replace( ' ', '_', strtolower( $this->carrier ) ), 10 ),
+                apply_filters( 'apa_enable_alexa_notifications_for_carrier_accepted_args_' . str_replace( ' ', '_', strtolower( $this->carrier ) ), 2 )
+            );
+        }
+    }
+}

--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -137,6 +137,7 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 			'hide_button_mode'                => 'no',
 			'amazon_keys_setup_and_validated' => '0',
 			'subscriptions_enabled'           => 'yes',
+			'alexa_notifications_support'     => 'no',
 		);
 
 		$settings = apply_filters( 'woocommerce_amazon_pa_settings', array_merge( $default, $settings ) );

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -92,6 +92,12 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 		return $ret;
 	}
 
+	/**
+	 * Enables Alexa Notifications for an order specified in $payload.
+	 *
+	 * @param array $payload
+	 * @return array
+	 */
 	public static function trigger_alexa_notifications( $payload ) {
 		return self::get_client()->deliveryTrackers( $payload );
 	}

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -92,6 +92,10 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 		return $ret;
 	}
 
+	public static function trigger_alexa_notifications( $payload ) {
+		return self::get_client()->deliveryTrackers( $payload );
+	}
+
 	/**
 	 * Add Amazon reference information in order item response.
 	 *

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -473,6 +473,14 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 				'type'        => 'checkbox',
 				'default'     => 'no',
 			),
+			'alexa_notifications_support'   => array(
+				'title'       => __( 'Support Alexa Delivery Notifications', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'label'       => __( 'Enable support for Alexa Delivery Notifications', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'description' => __( 'This will enable support for Alexa Delivery notifications.', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'desc_tip'    => true,
+				'type'        => 'checkbox',
+				'default'     => 'no',
+			),
 		);
 
 		if ( $this->has_other_gateways_enabled() ) {

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -235,6 +235,11 @@ class WC_Amazon_Payments_Advanced {
 			$this->gateway = new WC_Gateway_Amazon_Payments_Advanced_Legacy();
 		}
 		$this->gateway->gateway_settings_init();
+		/* Enable Alexa Notifications support based on Gateway's option. */
+		if ( ! empty( $this->settings['alexa_notifications_support'] ) && 'yes' === $this->settings['alexa_notifications_support'] ) {
+			include_once $this->includes_path . 'class-wc-amazon-payments-advanced-alexa-notifications.php';
+			new WC_Amazon_Payments_Advanced_Alexa_Notifications();
+		}
 	}
 
 	/**

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -235,6 +235,7 @@ class WC_Amazon_Payments_Advanced {
 			$this->gateway = new WC_Gateway_Amazon_Payments_Advanced_Legacy();
 		}
 		$this->gateway->gateway_settings_init();
+
 		/* Enable Alexa Notifications support based on Gateway's option. */
 		if ( ! empty( $this->settings['alexa_notifications_support'] ) && 'yes' === $this->settings['alexa_notifications_support'] ) {
 			include_once $this->includes_path . 'class-wc-amazon-payments-advanced-alexa-notifications.php';


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Adds support for Alexa Delivery Notifications. Shipping plugins can simply call

`do_action( 'apa_enable_alexa_notifications', $tracking_number, $carrier, $order_id );`

in a time where wc_get_order is applicable to be called, and as long as the merchant has enabled the corresponding option, alexa delivery notifications will be enabled for the $order_id.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Support for Alexa Delivery Notifications