### PR TITLE
Fix - site name too long error

### DIFF
--- a/includes/admin/class-wc-amazon-payments-advanced-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-admin.php
@@ -240,6 +240,28 @@ class WC_Amazon_Payments_Advanced_Admin {
 				'is_dismissable' => false,
 			);
 		}
+		$site_name = WC_Amazon_Payments_Advanced::get_site_name();
+		if ( 50 < strlen( $site_name ) ) {
+			$notices[] = array(
+				'dismiss_action' => 'amazon_pay_site_name_too_long_dismiss_notice',
+				'class'          => 'amazon_pay_site_name_too_long',
+				'text'           => sprintf(
+					/* translators: 1) The Site Name from Settings > General > Site Title. 2) URL to Settings > General > Site Title. */
+					__(
+						'Amazon Pay Gateway is <strong>not</strong> able to pass to Amazon your site\'s name as the 
+						<a target="_blank" rel="nofollow noopener" href="https://developer.amazon.com/docs/amazon-pay-checkout/buyer-communication.html">Merchant store name</a>.<br/>
+						This is happening because your current site name exceeds the 50 characters allowed by Amazon Pay API v2.<br/>
+						Your current site name is <strong>%1$s</strong> and can be changed from <a href="%2$s">Settings > General > Site Title</a>
+						The default you have set in your Amazon Merchant Account will be used instead.<br/>
+						This message\'s purpose is to notify you. Amazon Pay Gateway will continue to be functional without requiring an action from you.',
+						'woocommerce-gateway-amazon-payments-advanced'
+					),
+					$site_name,
+					esc_url( admin_url( '/options-general.php' ) )
+				),
+				'is_dismissable' => true,
+			);
+		}
 
 		return $notices;
 	}
@@ -274,9 +296,12 @@ class WC_Amazon_Payments_Advanced_Admin {
 							'title'       => array(),
 							'class'       => array(),
 							'data-toggle' => array(),
+							'target'      => array( '_self', '_blank' ),
+							'rel'         => array( 'nofollow', 'noopener' ),
 						),
 						'strong' => array(),
 						'em'     => array(),
+						'br'     => array(),
 					)
 				);
 				?>

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -765,11 +765,28 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 		/* translators: Plugin version */
 		$version_note = sprintf( __( 'Created by WC_Gateway_Amazon_Pay/%1$s (Platform=WooCommerce/%2$s)', 'woocommerce-gateway-amazon-payments-advanced' ), WC_AMAZON_PAY_VERSION, WC()->version );
 
-		return array(
+		$merchant_metadata = array(
 			'merchantReferenceId' => $order_id,
-			'merchantStoreName'   => WC_Amazon_Payments_Advanced::get_site_name(),
 			'customInformation'   => $version_note,
 		);
+
+		/**
+		 * Amazon Pay API v2 supports a merchantStoreName property of a 50 chars max length.
+		 * @see https://developer.amazon.com/docs/amazon-pay-api-v2/charge.html#type-merchantmetadata
+		 *
+		 * We could completely avoid providing this property, since it is used to overwrite what the merchant
+		 * has already configured it in his Amazon merchant account.
+		 * @see https://developer.amazon.com/docs/amazon-pay-checkout/buyer-communication.html
+		 *
+		 * For backwards compatibility though, we set the property for stores with an equal or
+		 * shorter than 50 chars site name.
+		 */
+		$site_name = WC_Amazon_Payments_Advanced::get_site_name();
+		if ( 50 >= strlen( $site_name ) ) {
+			$merchant_metadata['merchantStoreName'] = $site_name;
+		}
+
+		return $merchant_metadata;
 	}
 
 	/**

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -305,7 +305,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 			),
 			'enabled'                       => array(
 				'title'       => __( 'Enable/Disable', 'woocommerce-gateway-amazon-payments-advanced' ),
-				'label'       => __( 'Enable Amazon Pay &amp; Login with Amazon', 'woocommerce-gateway-amazon-payments-advanced' ),
+				'label'       => __( 'Enable Amazon Pay', 'woocommerce-gateway-amazon-payments-advanced' ),
 				'type'        => 'checkbox',
 				'description' => '',
 				'default'     => 'yes',


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes woo#138 .

### How to test the changes in this Pull Request:

1. payments should not fail even when the site name is more than 50 characters long

### Other information:

This PR includes the fixes introduced [here](https://github.com/saucal/woocommerce-gateway-amazon-pay/pull/141). The difference is that is created from main and it also amends this request https://app.clickup.com/t/27phubt

merchantStoreName is an optional field only used to overwrite what the merchant has already configured during his Merchant account set up.
@see https://developer.amazon.com/docs/amazon-pay-checkout/buyer-communication.html
@see https://developer.amazon.com/docs/amazon-pay-api-v2/charge.html#type-merchantmetadata

We could completely skip setting it, but for backwards compatibility we include it for sites with a site name equal or less than 50 characters.

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->
