### PR TITLE
fixes margins in mini-cart Amazon Pay button

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -133,3 +133,8 @@ span.wc-apa-amazon-logo {
 #pay_with_amazon_product {
 	margin: 0.7em auto;
 }
+
+.site-header .widget_shopping_cart div.buttons {
+    padding-left: 1.41575em;
+    padding-right: 1.41575em;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -81,7 +81,7 @@ img.wc-apa-amazon-logo {
 }
 
 span.wc-apa-amazon-logo {
-	background-image: url("../images/logo-amazonpay-primary-fullcolor-positive.svg");
+	background-image: url('../images/logo-amazonpay-primary-fullcolor-positive.svg');
 	background-position: 0 0;
 	background-size: contain;
 	background-repeat: no-repeat;
@@ -135,6 +135,6 @@ span.wc-apa-amazon-logo {
 }
 
 .site-header .widget_shopping_cart div.buttons {
-    padding-left: 1.41575em;
-    padding-right: 1.41575em;
+	padding-left: 1.41575em;
+	padding-right: 1.41575em;
 }

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -593,9 +593,15 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 */
 	public function maybe_separator_and_checkout_button() {
 		if ( $this->is_available() && $this->possible_subscription_cart_supported() && $this->is_mini_cart_button_enabled() && WC()->cart->get_cart_contents_count() > 0 ) {
-			$this->display_amazon_pay_button_separator_html();
-			$this->checkout_button( true, 'div', 'pay_with_amazon_cart' );
-			$this->update_js( 'wc-apa-update-vals-cart' );
+			?>
+			<div class="woocommerce-mini-cart__buttons buttons">
+				<?php
+				$this->display_amazon_pay_button_separator_html();
+				$this->checkout_button( true, 'div', 'pay_with_amazon_cart' );
+				$this->update_js( 'wc-apa-update-vals-cart' );
+				?>
+			</div>
+			<?php
 		}
 	}
 


### PR DESCRIPTION
Adds the amazon pay button to a container following WooCommerce's paddings.

Solves https://app.clickup.com/t/2a7r4pm