### PR TITLE
renders newers amazon buttons even if they are hidden

### DIFF
--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -168,7 +168,7 @@
 			$( buttonId ).each( function() {
 				var thisButton = $( this );
 				var thisId = thisButton.attr( 'id' );
-				if ( ! thisButton.is( ':visible' ) && classicButtonId !== '#' + thisId ) {
+				if ( button_id === '#' + thisId && ! thisButton.is( ':visible' ) ) {
 					return;
 				}
 				if ( typeof thisId === 'undefined' ) {


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Render Amazon Pay Buttons even if they are not :visible. Don't render them only if the target button has id `#pay_with_amazon` for backwards compatibility.

### How to test the changes in this Pull Request:

1. Prior to this, Amazon Button in the mini cart would only render if it was :visible
2. No it should render even if its not.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

No need for changelog entry, since the issue hasn't been introduced yet in the production version of the plugin.
