### PR TITLE
adjustment for region codes of JP region

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -11,6 +11,63 @@
 abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_Gateway {
 
 	/**
+	 * ISO region codes for JAPAN mapped to Japanese.
+	 *
+	 * Used to pass the region in Japanese to the Amazon API.
+	 *
+	 * Specifically requested by Amazon's JP Team.
+	 */
+	const JP_REGION_CODE_MAP = array(
+		'JP01' => '北海道',
+		'JP02' => '青森県',
+		'JP03' => '岩手県',
+		'JP04' => '宮城県',
+		'JP05' => '秋田県',
+		'JP06' => '山形県',
+		'JP07' => '福島県',
+		'JP08' => '茨城県',
+		'JP09' => '栃木県',
+		'JP10' => '群馬県',
+		'JP11' => '埼玉県',
+		'JP12' => '千葉県',
+		'JP13' => '東京都',
+		'JP14' => '神奈川県',
+		'JP15' => '新潟県',
+		'JP16' => '富山県',
+		'JP17' => '石川県',
+		'JP18' => '福井県',
+		'JP19' => '山梨県',
+		'JP20' => '長野県',
+		'JP21' => '岐阜県',
+		'JP22' => '静岡県',
+		'JP23' => '愛知県',
+		'JP24' => '三重県',
+		'JP25' => '滋賀県',
+		'JP26' => '京都府',
+		'JP27' => '大阪府',
+		'JP28' => '兵庫県',
+		'JP29' => '奈良県',
+		'JP30' => '和歌山県',
+		'JP31' => '鳥取県',
+		'JP32' => '島根県',
+		'JP33' => '岡山県',
+		'JP34' => '広島県',
+		'JP35' => '山口県',
+		'JP36' => '徳島県',
+		'JP37' => '香川県',
+		'JP38' => '愛媛県',
+		'JP39' => '高知県',
+		'JP40' => '福岡県',
+		'JP41' => '佐賀県',
+		'JP42' => '長崎県',
+		'JP43' => '熊本県',
+		'JP44' => '大分県',
+		'JP45' => '宮崎県',
+		'JP46' => '鹿児島県',
+		'JP47' => '沖縄県',
+	);
+
+	/**
 	 * Amazon Private Key
 	 *
 	 * @var string

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2813,16 +2813,22 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		$phone_number = $order->get_shipping_phone();
 		$phone_number = $phone_number ? $phone_number : $order->get_billing_phone();
 
+		$shipping_state = $order->get_shipping_state();
+
 		$payload['addressDetails'] = array(
 			'name'          => rawurlencode( $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name() ),
 			'addressLine1'  => rawurlencode( $order->get_shipping_address_1() ),
 			'addressLine2'  => rawurlencode( $order->get_shipping_address_2() ),
 			'city'          => rawurlencode( $order->get_shipping_city() ),
-			'stateOrRegion' => rawurlencode( $order->get_shipping_state() ),
+			'stateOrRegion' => rawurlencode( $shipping_state ),
 			'postalCode'    => rawurlencode( $order->get_shipping_postcode() ),
 			'countryCode'   => $order->get_shipping_country( 'edit' ),
 			'phoneNumber'   => rawurlencode( $phone_number ),
 		);
+
+		if ( 'JP' === strtoupper( $payload['addressDetails']['countryCode'] ) && 'JP' === strtoupper( WC_Amazon_Payments_Advanced_API::get_region() ) && isset( self::JP_REGION_CODE_MAP[ $shipping_state ] ) ) {
+			$payload['addressDetails']['stateOrRegion'] = rawurlencode( self::JP_REGION_CODE_MAP[ $shipping_state ] );
+		}
 
 		/**
 		 * Address Validation for the EU region.


### PR DESCRIPTION
Adds a map of JP ISO region codes to Japanese.

It will only alter the stateOrRegion value we send to Amazon when the selected country is JP, the Amazon pay configured region is JP and we also have a value for the selected ISO region code in our map.

