### PR TITLE
Hotfix/address details

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -343,7 +343,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 	/**
 	 * Filter the payload to add recurring data to the checkout session update object.
 	 *
-	 * @param  array    $payload Payload to send to the API before proceding to checkout.
+	 * @param  array    $payload Payload to send to the API before proceeding to checkout.
 	 * @param  string   $checkout_session_id Checkout Session Id.
 	 * @param  WC_Order $order Order object.
 	 * @param  bool     $doing_classic_payment Indicates whether this is an Amazon "Classic" Transaction or not.
@@ -359,33 +359,6 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			$payload['paymentDetails']['chargeAmount'] = WC_Amazon_Payments_Advanced::format_amount( $checkout_session->recurringMetadata->amount ); // phpcs:ignore WordPress.NamingConventions
 
 			return $payload;
-		}
-
-		if ( $doing_classic_payment && 'PayAndShip' === wc_apa()->get_gateway()->get_current_cart_action() ) {
-			$phone_number = $order->get_shipping_phone();
-			$phone_number = $phone_number ? $phone_number : $order->get_billing_phone();
-
-			$payload['addressDetails'] = array(
-				'name'          => rawurlencode( $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name() ),
-				'addressLine1'  => rawurlencode( $order->get_shipping_address_1() ),
-				'addressLine2'  => rawurlencode( $order->get_shipping_address_2() ),
-				'city'          => rawurlencode( $order->get_shipping_city() ),
-				'stateOrRegion' => rawurlencode( $order->get_shipping_state() ),
-				'postalCode'    => rawurlencode( $order->get_shipping_postcode() ),
-				'countryCode'   => $order->get_shipping_country( 'edit' ),
-				'phoneNumber'   => rawurlencode( $phone_number ),
-			);
-
-			/**
-			 * Address Validation for the EU region.
-			 *
-			 * @see https://developer.amazon.com/docs/amazon-pay-checkout/address-formatting-and-validation.html#address-validation
-			 */
-			if ( in_array( $payload['addressDetails']['countryCode'], array( 'UK', 'GB', 'SG', 'AE', 'MX' ), true ) ) {
-				$payload['addressDetails']['districtOrCounty'] = $payload['addressDetails']['stateOrRegion'];
-				unset( $payload['addressDetails']['stateOrRegion'] );
-				$payload['addressDetails'] = array_filter( $payload['addressDetails'] );
-			}
 		}
 
 		if ( ! WC_Subscriptions_Cart::cart_contains_subscription() && ( ! isset( $_GET['order_id'] ) || ! wcs_order_contains_subscription( $_GET['order_id'] ) ) ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -146,6 +146,9 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			return;
 		}
 
+		// Sets the payload's addressDetails property if checking out using Amazon "Classic" and there is a physical product.
+		add_filter( 'woocommerce_amazon_pa_update_checkout_session_payload', array( $this, 'update_address_details_for_classic' ), 10, 4 );
+
 		// Scripts.
 		add_action( 'wp_enqueue_scripts', array( $this, 'scripts' ) );
 
@@ -2791,5 +2794,47 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		}
 
 		return ! WC_Subscriptions_Cart::cart_contains_subscription();
+	}
+
+	/**
+	 * Filter the payload to add the addressDetails data to the checkout session object.
+	 *
+	 * @param  array    $payload Payload to send to the API before proceeding to checkout.
+	 * @param  string   $checkout_session_id Checkout Session Id.
+	 * @param  WC_Order $order Order object.
+	 * @param  bool     $doing_classic_payment Indicates whether this is an Amazon "Classic" Transaction or not.
+	 * @return array
+	 */
+	public function update_address_details_for_classic( $payload, $checkout_session_id, $order, $doing_classic_payment ) {
+		if ( ! $doing_classic_payment || 'PayAndShip' !== wc_apa()->get_gateway()->get_current_cart_action() ) {
+			return $payload;
+		}
+
+		$phone_number = $order->get_shipping_phone();
+		$phone_number = $phone_number ? $phone_number : $order->get_billing_phone();
+
+		$payload['addressDetails'] = array(
+			'name'          => rawurlencode( $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name() ),
+			'addressLine1'  => rawurlencode( $order->get_shipping_address_1() ),
+			'addressLine2'  => rawurlencode( $order->get_shipping_address_2() ),
+			'city'          => rawurlencode( $order->get_shipping_city() ),
+			'stateOrRegion' => rawurlencode( $order->get_shipping_state() ),
+			'postalCode'    => rawurlencode( $order->get_shipping_postcode() ),
+			'countryCode'   => $order->get_shipping_country( 'edit' ),
+			'phoneNumber'   => rawurlencode( $phone_number ),
+		);
+
+		/**
+		 * Address Validation for the EU region.
+		 *
+		 * @see https://developer.amazon.com/docs/amazon-pay-checkout/address-formatting-and-validation.html#address-validation
+		 */
+		if ( in_array( $payload['addressDetails']['countryCode'], array( 'UK', 'GB', 'SG', 'AE', 'MX' ), true ) ) {
+			$payload['addressDetails']['districtOrCounty'] = $payload['addressDetails']['stateOrRegion'];
+			unset( $payload['addressDetails']['stateOrRegion'] );
+			$payload['addressDetails'] = array_filter( $payload['addressDetails'] );
+		}
+
+		return $payload;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

#### This PR Fixes issues not yet released. So it does not close any issues nor it needs a changelog entry.

### Changes proposed in this Pull Request:

Summary: When using amazon pay "classic" and there are physical goods in the cart being checked out, we need to provide to amazon a property "addressDetails". The following bugs were identified and fixed:

- The property was being filled only when WooCommerce Subscriptions plugin was active.
- Encoding needed to change from utf8_encode to rawurlencode since some special characters weren't appearing correctly in Amazon.
- When the country code was UK, GB, SG, AE or MX, amazon classic would always fail address validation.

### Additonally:
Adds a map of JP ISO region codes to Japanese.

It will only alter the stateOrRegion value we send to Amazon when the selected country is JP, the Amazon pay configured region is JP and we also have a value for the selected ISO region code in our map.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

