### PR TITLE
phonerequired only whenphysical products in cart

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1266,6 +1266,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			return;
 		}
 
+		// If its virtual only bail.
+		if ( 'PayOnly' === $this->get_current_cart_action() ) {
+			return;
+		}
+
 		if ( ! empty( $data['billing_phone'] ) || ! empty( $data['shipping_phone'] ) ) {
 			return;
 		}

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -62,6 +62,9 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		// Mini cart regeneration needs to be hooked really early.
 		add_action( 'woocommerce_widget_shopping_cart_buttons', array( $this, 'maybe_separator_and_checkout_button' ), 30 );
+
+		// Sets the payload's addressDetails property if checking out using Amazon "Classic" and there is a physical product.
+		add_filter( 'woocommerce_amazon_pa_update_checkout_session_payload', array( $this, 'update_address_details_for_classic' ), 10, 4 );
 	}
 
 	/**
@@ -145,9 +148,6 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( ! isset( $available_gateways[ $this->id ] ) ) {
 			return;
 		}
-
-		// Sets the payload's addressDetails property if checking out using Amazon "Classic" and there is a physical product.
-		add_filter( 'woocommerce_amazon_pa_update_checkout_session_payload', array( $this, 'update_address_details_for_classic' ), 10, 4 );
 
 		// Scripts.
 		add_action( 'wp_enqueue_scripts', array( $this, 'scripts' ) );

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
@@ -34,6 +34,23 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 	}
 
 	/**
+	 * Returns the frontend accessible data.
+	 *
+	 * Can be accessed by calling
+	 * const settings = wc.wcSettings.getSetting( '{paymentMethodName}_data' );
+	 *
+	 * @return array
+	 */
+	public function get_payment_method_data() {
+		return array(
+			'title'       => $this->settings['title'],
+			'description' => $this->settings['description'],
+			'supports'    => $this->get_supported_features(),
+			'action'      => wc_apa()->get_gateway()->get_current_cart_action(),
+		);
+	}
+
+	/**
 	 * Returns the scripts required by the payment method based on the $type param.
 	 *
 	 * @param string $type Can be 'backend' or 'frontend'.

--- a/src/payments-methods/classic/payment-methods.js
+++ b/src/payments-methods/classic/payment-methods.js
@@ -5,13 +5,14 @@ import { __ } from '@wordpress/i18n';
 import { renderAndInitAmazonCheckout } from '../../renderAmazonButton';
 import React from 'react';
 
+const settings = getBlocksConfiguration( 'amazon_payments_advanced_data' );
+
 /**
  * Returns the payment method's description.
  *
  * @returns {string}
  */
 const Content = () => {
-	const settings = getBlocksConfiguration( 'amazon_payments_advanced_data' );
 	return decodeEntities( settings.description || '' );
 };
 
@@ -21,6 +22,8 @@ const Content = () => {
  * @returns React component
  */
 const AmazonPayBtn = ( props ) => {
+	const { action } = settings;
+
 	useEffect( () => {
 		const unsubscribe = props.eventRegistration.onCheckoutAfterProcessingWithSuccess(
 			async ( { processingResponse } ) => {
@@ -44,6 +47,9 @@ const AmazonPayBtn = ( props ) => {
 	useEffect( () => {
 		const unsubscribe = props.eventRegistration.onPaymentProcessing(
 			async () => {
+				if ( 'PayOnly' === action ) {
+					return true;
+				}
 				const shippingPhone = document.getElementById( 'shipping-phone' );
 				const billingPhone = document.getElementById( 'phone' );
 				if ( ! shippingPhone?.value && ! billingPhone?.value ) {
@@ -61,6 +67,7 @@ const AmazonPayBtn = ( props ) => {
 		props.emitResponse.noticeContexts.PAYMENTS,
 		props.emitResponse.responseTypes.ERROR,
 		props.emitResponse.responseTypes.SUCCESS,
+		action,
 	] );
 
 	return <div id="classic_pay_with_amazon" />;


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When amazon classic is used with physical products, a phone number is required to be provided. When the cart contains only virtual products the phone should not be required.

Closes woo#187.

### How to test the changes in this Pull Request:

1. Create an order containing only physical products and one containing only virtual products.
2. In the first case, you shouldn't be able to complete checkout without providing a phone number.
3. In the second you should.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Phone number should not be required when no physical products are present in cart.
