### PR TITLE
Updated estimated order amount on total change for blocks

### DIFF
--- a/src/payments-methods/express/payment-methods-express.js
+++ b/src/payments-methods/express/payment-methods-express.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,11 +14,25 @@ import { renderAmazonButton } from '../../renderAmazonButton';
  * @returns React component
  */
 const AmazonPayExpressBtn = ( props ) => {
+	const estimatedOrderAmount = calculateEstimatedOrderAmount( props );
+
 	useEffect( () => {
-		renderAmazonButton( '#pay_with_amazon_express', 'express', null );
+		renderAmazonButton( '#pay_with_amazon_express', 'express', null, estimatedOrderAmount );
 	}, [] );
 
 	return <div id="pay_with_amazon_express" />;
+};
+
+const calculateEstimatedOrderAmount = ( props ) => {
+	const { billing } = props;
+	const { currency } = billing;
+
+	const stringCartTotal     = String( billing.cartTotal.value );
+	const cartTotalLength     = stringCartTotal.length;
+	const decimals            = currency.minorUnit;
+	const checkOutValue       = stringCartTotal.slice( 0, cartTotalLength - decimals ) + '.' + stringCartTotal.slice( cartTotalLength - decimals );
+
+	return cartTotalLength < decimals ? null : { amount: checkOutValue, currencyCode: currency.code };
 };
 
 /**
@@ -28,5 +42,15 @@ const AmazonPayExpressBtn = ( props ) => {
  * @returns React Component
  */
 export const AmazonExpressContent = ( props ) => {
-	return <AmazonPayExpressBtn { ...props } />;
+	const estimatedOrderAmount = calculateEstimatedOrderAmount( props );
+
+	const [id, setId] = useState( estimatedOrderAmount ? estimatedOrderAmount.amount + estimatedOrderAmount.currencyCode : '0' );
+
+	useEffect( () => {
+		setId( estimatedOrderAmount ? estimatedOrderAmount.amount + estimatedOrderAmount.currencyCode : '0' );
+	}, [
+		estimatedOrderAmount
+	] );
+
+	return <AmazonPayExpressBtn key={id} { ...props } />;
 };

--- a/src/renderAmazonButton.js
+++ b/src/renderAmazonButton.js
@@ -5,9 +5,11 @@
  *
  * @param {string} buttonSettingsFlag Specifies the context of the rendering.
  * @param {string} checkoutConfig The checkoutConfig with which we will provide Amazon Pay.
+ * @param {object} estimatedOrderAmount The estimatedOrderAmount object or null to be passed to the Button's settings.
  * @returns {object} The settings to provide the Amazon Pay Button with.
  */
-const getButtonSettings = ( buttonSettingsFlag, checkoutConfig ) => {
+const getButtonSettings = ( buttonSettingsFlag, checkoutConfig, estimatedOrderAmount ) => {
+	estimatedOrderAmount = estimatedOrderAmount || amazon_payments_advanced.estimated_order_amount;
 	let obj = {
 		// set checkout environment
 		merchantId: amazon_payments_advanced.merchant_id,
@@ -16,7 +18,7 @@ const getButtonSettings = ( buttonSettingsFlag, checkoutConfig ) => {
 		// customize the buyer experience
 		placement: amazon_payments_advanced.placement,
 		buttonColor: amazon_payments_advanced.button_color,
-		estimatedOrderAmount: amazon_payments_advanced.estimated_order_amount,
+		estimatedOrderAmount: estimatedOrderAmount,
 		checkoutLanguage:
 			amazon_payments_advanced.button_language !== ''
 				? amazon_payments_advanced.button_language.replace( '-', '_' )
@@ -39,16 +41,18 @@ const getButtonSettings = ( buttonSettingsFlag, checkoutConfig ) => {
  * @param {string} buttonId Selector on where the Amazon Pay button will be rendered on.
  * @param {string} buttonSettingsFlag Specifies the context of the rendering.
  * @param {string} checkoutConfig The checkoutConfig with which we will provide Amazon Pay.
+ * @param {object} estimatedOrderAmount The estimatedOrderAmount object or null to be passed to the Button's settings.
  * @returns {object} The Amazon Pay rendered button.
  */
-export const renderAmazonButton = ( buttonId, buttonSettingsFlag, checkoutConfig ) => {
+export const renderAmazonButton = ( buttonId, buttonSettingsFlag, checkoutConfig, estimatedOrderAmount ) => {
 	let amazonPayButton = null;
 	const buttons = document.querySelectorAll( buttonId );
 	for ( const button of buttons ) {
 		const thisId = '#' + button.getAttribute( 'id' );
 		const buttonSettings = getButtonSettings(
 			buttonSettingsFlag,
-			checkoutConfig
+			checkoutConfig,
+			estimatedOrderAmount
 		);
 		amazonPayButton = amazon.Pay.renderButton( thisId, buttonSettings );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Listening for changes on the total amount for the checkout and/or the currency code. If that happens using the Components key attribute, we force a remount and render the new Amazon Pay button using the updated estimatedOrderAmount value.

### How to test the changes in this Pull Request:

1. Estimated order amount should get updated after the checkout total is changed in cart and checkout blocks

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->