### PR TITLE
Making Plugin compatible with HPOS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,6 @@ docker-compose.yml export-ignore
 docs/DOCKER.md export-ignore
 wordpress_org_assets export-ignore
 src export-ignore
+node_modules export-ignore
+.prettierrc.js export-ignore
+woocommerce-gateway-amazon-pay.zip export-ignore

--- a/assets/js/amazon-wc-admin.js
+++ b/assets/js/amazon-wc-admin.js
@@ -366,7 +366,7 @@
 			window.onbeforeunload = null;
 		} );
 	}
-	if ( $( 'body' ).hasClass( 'post-type-shop_order' ) ) {
+	if ( $( 'body' ).hasClass( 'post-type-shop_order' ) || $( 'body' ).hasClass( 'woocommerce_page_wc-orders' ) ) {
 		jQuery( '#woocommerce-amazon-payments-advanced.postbox' ).each( function() {
 			var thisPostBox = $( this );
 

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,20 @@
     "config": {
         "platform": {
             "php": "7.3"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
         }
     },
+    "scripts": {
+		"phpcs": [
+			"phpcs . --ignore=vendor,node_modules,build --extensions=php -s -p"
+		],
+        "phpcbf": [
+			"phpcbf . --ignore=vendor,node_modules,build --extensions=php -p"
+		]
+	},
     "require-dev": {
         "phpunit/phpunit": "5.7.27",
         "woocommerce/woocommerce-sniffs": "0.1.0",

--- a/includes/admin/class-wc-amazon-payments-advanced-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-admin.php
@@ -355,13 +355,7 @@ class WC_Amazon_Payments_Advanced_Admin {
 			$current_screen = 'wc_apa_settings';
 		}
 
-		if ( function_exists( 'wc_get_container' ) && class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
-			$screen_to_check = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
-			? wc_get_page_screen_id( 'shop-order' )
-			: 'shop_order';
-		} else {
-			$screen_to_check = 'shop_order';
-		}
+		$screen_to_check = WC_Amazon_Payments_Advanced_Utils::get_edit_order_screen_id();
 
 		switch ( $current_screen ) {
 			case $screen_to_check:

--- a/includes/admin/class-wc-amazon-payments-advanced-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-admin.php
@@ -355,8 +355,16 @@ class WC_Amazon_Payments_Advanced_Admin {
 			$current_screen = 'wc_apa_settings';
 		}
 
+		if ( function_exists( 'wc_get_container' ) && class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
+			$screen_to_check = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+			? wc_get_page_screen_id( 'shop-order' )
+			: 'shop_order';
+		} else {
+			$screen_to_check = 'shop_order';
+		}
+
 		switch ( $current_screen ) {
-			case 'shop_order':
+			case $screen_to_check:
 			case 'wc_apa_settings':
 				break;
 			default:

--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -154,7 +154,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 	/**
 	 * Authorization metabox content.
 	 *
-	 * @param Object $object The current post/order object.
+	 * @param WC_Order|WP_Post $object The current post/order object.
 	 * @return void
 	 */
 	public function authorization_box( $object ) {

--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -66,8 +66,11 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 		}
 
 		$order_id = absint( $order_id );
-		$order    = wc_get_order( $order_id );
+		if ( ! $order_id ) {
+			return;
+		}
 
+		$order = wc_get_order( $order_id );
 		if ( ! ( $order instanceof \WC_Order ) ) {
 			return;
 		}

--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -54,8 +54,10 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 
 		check_admin_referer( 'amazon_order_action', 'security' );
 
+		// Find order id with HPOS disabled.
 		$order_id = ! empty( $_GET['post'] ) ? $_GET['post'] : false;
 		if ( ! $order_id ) {
+			// Find order id with HPOS enabled.
 			$order_id = ! empty( $_GET['id'] ) ? $_GET['id'] : false;
 		}
 

--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -42,13 +42,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 	 * Non AJAX handler that performs order actions.
 	 */
 	public function order_actions_non_ajax() {
-		if ( function_exists( 'wc_get_container' ) && class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
-			$screen_to_check = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
-			? wc_get_page_screen_id( 'shop-order' )
-			: 'shop_order';
-		} else {
-			$screen_to_check = 'shop_order';
-		}
+		$screen_to_check = WC_Amazon_Payments_Advanced_Utils::get_edit_order_screen_id();
 
 		if ( get_current_screen()->id !== $screen_to_check ) {
 			return;
@@ -140,13 +134,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 			return;
 		}
 
-		if ( function_exists( 'wc_get_container' ) && class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
-			$screen = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
-			? wc_get_page_screen_id( 'shop-order' )
-			: 'shop_order';
-		} else {
-			$screen = 'shop_order';
-		}
+		$screen = WC_Amazon_Payments_Advanced_Utils::get_edit_order_screen_id();
 
 		$post_types = apply_filters( 'woocommerce_amazon_pa_admin_meta_box_post_types', array( $screen ) );
 

--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -42,7 +42,15 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 	 * Non AJAX handler that performs order actions.
 	 */
 	public function order_actions_non_ajax() {
-		if ( 'shop_order' !== get_current_screen()->id ) {
+		if ( function_exists( 'wc_get_container' ) && class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
+			$screen_to_check = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+			? wc_get_page_screen_id( 'shop-order' )
+			: 'shop_order';
+		} else {
+			$screen_to_check = 'shop_order';
+		}
+
+		if ( $screen_to_check !== get_current_screen()->id ) {
 			return;
 		}
 
@@ -123,7 +131,6 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 		} else {
 			$screen = 'shop_order';
 		}
-
 
 		$post_types = apply_filters( 'woocommerce_amazon_pa_admin_meta_box_post_types', array( $screen ) );
 

--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -50,7 +50,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 			$screen_to_check = 'shop_order';
 		}
 
-		if ( $screen_to_check !== get_current_screen()->id ) {
+		if ( get_current_screen()->id !== $screen_to_check ) {
 			return;
 		}
 
@@ -112,6 +112,10 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 
 	/**
 	 * Amazon Pay authorization metabox.
+	 *
+	 * @param Object           $screen The current screen object.
+	 * @param WC_Order|WP_Post $order The current post/order object.
+	 * @return void
 	 */
 	public function meta_box( $screen, $order ) {
 
@@ -147,6 +151,9 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 
 	/**
 	 * Authorization metabox content.
+	 *
+	 * @param Object $object The current post/order object.
+	 * @return void
 	 */
 	public function authorization_box( $object ) {
 		$order = $object instanceof WC_Order ? $object : wc_get_order( $object->ID );

--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -60,8 +60,17 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 
 		check_admin_referer( 'amazon_order_action', 'security' );
 
-		$order_id = absint( $_GET['post'] ); // TODO: This may break when custom data stores are implemented in the future.
+		$order_id = ! empty( $_GET['post'] ) ? $_GET['post'] : false;
+		if ( ! $order_id ) {
+			$order_id = ! empty( $_GET['id'] ) ? $_GET['id'] : false;
+		}
+
+		$order_id = absint( $order_id );
 		$order    = wc_get_order( $order_id );
+
+		if ( ! ( $order instanceof \WC_Order ) ) {
+			return;
+		}
 
 		$version = WC_Amazon_Payments_Advanced::get_order_version( $order_id );
 

--- a/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
+++ b/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
@@ -42,8 +42,9 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 				$this->clear_stored_states( $order_id );
 				break;
 			case 'authorize':
-				delete_post_meta( $order_id, 'amazon_authorization_id' );
-				delete_post_meta( $order_id, 'amazon_capture_id' );
+				$order->delete_meta_data( 'amazon_authorization_id' );
+				$order->delete_meta_data( 'amazon_capture_id' );
+				$order->save();
 
 				// $id is order reference.
 				wc_apa()->log( 'Info: Trying to authorize payment in order reference ' . $id );
@@ -52,8 +53,9 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 				$this->clear_stored_states( $order_id );
 				break;
 			case 'authorize_capture':
-				delete_post_meta( $order_id, 'amazon_authorization_id' );
-				delete_post_meta( $order_id, 'amazon_capture_id' );
+				$order->delete_meta_data( 'amazon_authorization_id' );
+				$order->delete_meta_data( 'amazon_capture_id' );
+				$order->save();
 
 				// $id is order reference.
 				wc_apa()->log( 'Info: Trying to authorize and capture payment in order reference ' . $id );
@@ -108,9 +110,11 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 	 * @param int $order_id Order ID.
 	 */
 	private function clear_stored_states( $order_id ) {
-		delete_post_meta( $order_id, 'amazon_reference_state' );
-		delete_post_meta( $order_id, 'amazon_capture_state' );
-		delete_post_meta( $order_id, 'amazon_authorization_state' );
+		$order = wc_get_order( $order_id );
+		$order->delete_meta_data( 'amazon_reference_state' );
+		$order->delete_meta_data( 'amazon_capture_state' );
+		$order->delete_meta_data( 'amazon_authorization_state' );
+		$order->save();
 		do_action( 'woocommerce_amazon_pa_v1_cleared_stored_states', $order_id );
 	}
 
@@ -150,10 +154,10 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 		$order_id = $order->get_id();
 
 		// Get ids.
-		$amazon_authorization_id = get_post_meta( $order_id, 'amazon_authorization_id', true );
-		$amazon_reference_id     = get_post_meta( $order_id, 'amazon_reference_id', true );
-		$amazon_capture_id       = get_post_meta( $order_id, 'amazon_capture_id', true );
-		$amazon_refund_ids       = get_post_meta( $order_id, 'amazon_refund_id', false );
+		$amazon_authorization_id = $order->get_meta( 'amazon_authorization_id', true, 'edit' );
+		$amazon_reference_id     = $order->get_meta( 'amazon_reference_id', true, 'edit' );
+		$amazon_capture_id       = $order->get_meta( 'amazon_capture_id', true, 'edit' );
+		$amazon_refund_ids       = $order->get_meta( 'amazon_refund_id', false, 'edit' );
 
 		$override = apply_filters( 'woocommerce_amazon_pa_v1_order_admin_actions_panel', false, $order, $actions );
 
@@ -203,7 +207,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 
 			// Display refunds.
 			if ( $amazon_refund_ids ) {
-				$refunds = (array) get_post_meta( $order_id, 'amazon_refunds', true );
+				$refunds = (array) $order->get_meta( 'amazon_refunds', true, 'edit' );
 
 				foreach ( $amazon_refund_ids as $amazon_refund_id ) {
 
@@ -241,7 +245,8 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 					}
 				}
 
-				update_post_meta( $order_id, 'amazon_refunds', $refunds );
+				$order->update_meta_data( 'amazon_refunds', $refunds );
+				$order->save();
 			}
 		} elseif ( $amazon_authorization_id ) {
 

--- a/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
+++ b/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
@@ -119,6 +119,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 		$order->delete_meta_data( 'amazon_capture_state' );
 		$order->delete_meta_data( 'amazon_authorization_state' );
 		$order->save();
+
 		do_action( 'woocommerce_amazon_pa_v1_cleared_stored_states', $order_id );
 	}
 

--- a/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
+++ b/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
@@ -111,6 +111,10 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 	 */
 	private function clear_stored_states( $order_id ) {
 		$order = wc_get_order( $order_id );
+		if ( ! ( $order instanceof WC_Order ) ) {
+			return;
+		}
+
 		$order->delete_meta_data( 'amazon_reference_state' );
 		$order->delete_meta_data( 'amazon_capture_state' );
 		$order->delete_meta_data( 'amazon_authorization_state' );

--- a/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
+++ b/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
@@ -259,6 +259,7 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 			$order->delete_meta_data( 'amazon_capture_state' );
 			$order->delete_meta_data( 'amazon_authorization_state' );
 			$order->save();
+
 			wc_apa()->get_gateway()->refresh_cached_charge_permission_status( $order );
 			wc_apa()->get_gateway()->get_cached_charge_status( $order );
 		}

--- a/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
+++ b/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
@@ -246,39 +246,38 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 * @return array|WP_Error|WP_REST_Response
 	 */
 	public function get_reference_state( $request ) {
-		$order_post = $this->is_valid_order( $request['order_id'] );
+		$or = $this->is_valid_order( $request['order_id'] );
 
-		if ( is_wp_error( $order_post ) ) {
-			return $order_post;
+		if ( is_wp_error( $or ) ) {
+			return $or;
 		}
-
-		$order = wc_get_order( $order_post->ID );
 
 		// If `refresh=1` is passed, cache ref states will be cleared so it
 		// makes a call to Amazon to get the details.
 		if ( ! empty( $request['refresh'] ) ) {
-			delete_post_meta( $order_post->ID, 'amazon_reference_state' );
-			delete_post_meta( $order_post->ID, 'amazon_capture_state' );
-			delete_post_meta( $order_post->ID, 'amazon_authorization_state' );
-			wc_apa()->get_gateway()->refresh_cached_charge_permission_status( $order );
-			wc_apa()->get_gateway()->get_cached_charge_status( $order );
+			$or->delete_meta_data( 'amazon_reference_state' );
+			$or->delete_meta_data( 'amazon_capture_state' );
+			$or->delete_meta_data( 'amazon_authorization_state' );
+			$or->save();
+			wc_apa()->get_gateway()->refresh_cached_charge_permission_status( $or );
+			wc_apa()->get_gateway()->get_cached_charge_status( $or );
 		}
 
-		$charge_permission_id            = WC_Amazon_Payments_Advanced::get_order_charge_permission( $order->get_id() );
-		$charge_permission_cached_status = wc_apa()->get_gateway()->get_cached_charge_permission_status( $order, true );
+		$charge_permission_id            = WC_Amazon_Payments_Advanced::get_order_charge_permission( $or->get_id() );
+		$charge_permission_cached_status = wc_apa()->get_gateway()->get_cached_charge_permission_status( $or, true );
 
-		$charge_id            = WC_Amazon_Payments_Advanced::get_order_charge_id( $order->get_id() );
-		$charge_cached_status = wc_apa()->get_gateway()->get_cached_charge_status( $order, true );
+		$charge_id            = WC_Amazon_Payments_Advanced::get_order_charge_id( $or->get_id() );
+		$charge_cached_status = wc_apa()->get_gateway()->get_cached_charge_status( $or, true );
 
 		// TODO: Implement subscriptions v1 billing agreement, along with auth and capture methods for that.
 
 		$ref_detail = array(
-			'amazon_reference_state'         => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $order_post->ID, 'amazon_reference_state' ),
-			'amazon_reference_id'            => get_post_meta( $order_post->ID, 'amazon_reference_id', true ),
-			'amazon_authorization_state'     => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $order_post->ID, 'amazon_authorization_state' ),
-			'amazon_authorization_id'        => get_post_meta( $order_post->ID, 'amazon_authorization_id', true ),
-			'amazon_capture_state'           => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $order_post->ID, 'amazon_capture_state' ),
-			'amazon_capture_id'              => get_post_meta( $order_post->ID, 'amazon_capture_id', true ),
+			'amazon_reference_state'         => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $or->get_id(), 'amazon_reference_state' ),
+			'amazon_reference_id'            => $or->get_meta( 'amazon_reference_id', true, 'edit' ),
+			'amazon_authorization_state'     => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $or->get_id(), 'amazon_authorization_state' ),
+			'amazon_authorization_id'        => $or->get_meta( 'amazon_authorization_id', true, 'edit' ),
+			'amazon_capture_state'           => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $or->get_id(), 'amazon_capture_state' ),
+			'amazon_capture_id'              => $or->get_meta( 'amazon_capture_id', true, 'edit' ),
 			'amazon_charge_permission_state' => $charge_permission_cached_status->status ? $charge_permission_cached_status->status : '',
 			'amazon_charge_permission_id'    => $charge_permission_id,
 			'amazon_charge_state'            => $charge_cached_status->status ? $charge_cached_status->status : '',
@@ -299,28 +298,28 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 *                                   WP_REST_Response instance.
 	 */
 	public function authorize( $request ) {
-		$order_post = $this->is_valid_order( $request['order_id'] );
-		if ( is_wp_error( $order_post ) ) {
-			return $order_post;
+		$or = $this->is_valid_order( $request['order_id'] );
+		if ( is_wp_error( $or ) ) {
+			return $or;
 		}
-		$order   = wc_get_order( $order_post->ID );
-		$version = WC_Amazon_Payments_Advanced::get_order_version( $order_post->ID );
+
+		$version = WC_Amazon_Payments_Advanced::get_order_version( $or->get_id() );
 		if ( 'v1' === strtolower( $version ) ) {
-			$error = $this->get_missing_reference_id_request_error( $order_post );
+			$error = $this->get_missing_reference_id_request_error( $or );
 			if ( is_wp_error( $error ) ) {
 				return $error;
 			}
 
-			return $this->authorize_order_v1( $order_post->ID );
+			return $this->authorize_order_v1( $or->get_id() );
 		} else {
 			$result             = array();
-			$charge             = wc_apa()->get_gateway()->perform_authorization( $order, false );
+			$charge             = wc_apa()->get_gateway()->perform_authorization( $or, false );
 			$result['captured'] = false;
 			if ( is_wp_error( $charge ) ) {
 				$result['authorized'] = false;
 			} else {
 				$result['authorized']       = true;
-				$result['amazon_charge_id'] = WC_Amazon_Payments_Advanced::get_order_charge_id( $order->get_id() );
+				$result['amazon_charge_id'] = WC_Amazon_Payments_Advanced::get_order_charge_id( $or->get_id() );
 			}
 			return rest_ensure_response( $result );
 		}
@@ -337,29 +336,29 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 *                                   WP_REST_Response instance.
 	 */
 	public function authorize_and_capture( $request ) {
-		$order_post = $this->is_valid_order( $request['order_id'] );
-		if ( is_wp_error( $order_post ) ) {
-			return $order_post;
+		$or = $this->is_valid_order( $request['order_id'] );
+		if ( is_wp_error( $or ) ) {
+			return $or;
 		}
-		$order   = wc_get_order( $order_post->ID );
-		$version = WC_Amazon_Payments_Advanced::get_order_version( $order_post->ID );
+
+		$version = WC_Amazon_Payments_Advanced::get_order_version( $or->get_id() );
 		if ( 'v1' === strtolower( $version ) ) {
-			$error = $this->get_missing_reference_id_request_error( $order_post );
+			$error = $this->get_missing_reference_id_request_error( $or );
 			if ( is_wp_error( $error ) ) {
 				return $error;
 			}
 
-			return $this->authorize_order_v1( $order_post->ID, array( 'capture_now' => true ) );
+			return $this->authorize_order_v1( $or->get_id(), array( 'capture_now' => true ) );
 		} else {
 			$result = array();
-			$charge = wc_apa()->get_gateway()->perform_authorization( $order, true );
+			$charge = wc_apa()->get_gateway()->perform_authorization( $or, true );
 			if ( is_wp_error( $charge ) ) {
 				$result['authorized'] = false;
 				$result['captured']   = false;
 			} else {
 				$result['authorized']       = true;
 				$result['captured']         = true;
-				$result['amazon_charge_id'] = WC_Amazon_Payments_Advanced::get_order_charge_id( $order->get_id() );
+				$result['amazon_charge_id'] = WC_Amazon_Payments_Advanced::get_order_charge_id( $or->get_id() );
 			}
 			return rest_ensure_response( $result );
 		}
@@ -384,16 +383,18 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 			return $resp;
 		}
 
+		$or = wc_get_order( $order_id );
+
 		$result = WC_Amazon_Payments_Advanced_API_Legacy::handle_payment_authorization_response( $resp, $order_id, $authorize_args['capture_now'] );
 
 		$ret = array(
 			'authorized'              => $result,
-			'amazon_authorization_id' => get_post_meta( $order_id, 'amazon_authorization_id', true ),
+			'amazon_authorization_id' => $or->get_meta( 'amazon_authorization_id', true, 'edit' ),
 		);
 
 		if ( $authorize_args['capture_now'] ) {
 			$ret['captured']          = $result;
-			$ret['amazon_capture_id'] = get_post_meta( $order_id, 'amazon_capture_id', true );
+			$ret['amazon_capture_id'] = $or->get_meta( 'amazon_capture_id', true, 'edit' );
 
 			$order_closed = WC_Amazon_Payments_Advanced_API_Legacy::close_order_reference( $order_id );
 			$order_closed = ( ! is_wp_error( $order_closed ) && $order_closed );
@@ -415,22 +416,20 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 *                                   WP_REST_Response instance.
 	 */
 	public function close_authorization( $request ) {
-		$order_post = $this->is_valid_order( $request['order_id'] );
-		if ( is_wp_error( $order_post ) ) {
-			return $order_post;
+		$or = $this->is_valid_order( $request['order_id'] );
+		if ( is_wp_error( $or ) ) {
+			return $or;
 		}
 
-		$order   = wc_get_order( $order_post->ID );
-		$version = WC_Amazon_Payments_Advanced::get_order_version( $order_post->ID );
+		$version = WC_Amazon_Payments_Advanced::get_order_version( $or->get_id() );
 		if ( 'v1' === strtolower( $version ) ) {
-			$error = $this->get_missing_authorization_id_request_error( $order_post );
+			$error = $this->get_missing_authorization_id_request_error( $or );
 			if ( is_wp_error( $error ) ) {
 				return $error;
 			}
 
-			$order_id = (int) $request['order_id'];
-			$auth_id  = get_post_meta( $order_id, 'amazon_authorization_id', true );
-			$resp     = WC_Amazon_Payments_Advanced_API_Legacy::close_authorization( $order_id, $auth_id );
+			$auth_id  = $or->get_meta( 'amazon_authorization_id', true, true );
+			$resp     = WC_Amazon_Payments_Advanced_API_Legacy::close_authorization( $or->get_id(), $auth_id );
 			if ( is_wp_error( $resp ) ) {
 				return $resp;
 			}
@@ -442,7 +441,7 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 			return rest_ensure_response( $ret );
 		} else {
 			$result = array();
-			$charge = wc_apa()->get_gateway()->perform_cancel_auth( $order );
+			$charge = wc_apa()->get_gateway()->perform_cancel_auth( $or );
 			if ( is_wp_error( $charge ) ) {
 				$result['authorization_closed'] = false;
 			} else {
@@ -463,49 +462,46 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 *                                   WP_REST_Response instance.
 	 */
 	public function capture( $request ) {
-		$order_post = $this->is_valid_order( $request['order_id'] );
-		if ( is_wp_error( $order_post ) ) {
-			return $order_post;
+		$or = $this->is_valid_order( $request['order_id'] );
+		if ( is_wp_error( $or ) ) {
+			return $or;
 		}
 
-		$order   = wc_get_order( $order_post->ID );
-		$version = WC_Amazon_Payments_Advanced::get_order_version( $order_post->ID );
+		$version = WC_Amazon_Payments_Advanced::get_order_version( $or->get_id() );
 		if ( 'v1' === strtolower( $version ) ) {
-			$error = $this->get_missing_authorization_id_request_error( $order_post );
+			$error = $this->get_missing_authorization_id_request_error( $or );
 			if ( is_wp_error( $error ) ) {
 				return $error;
 			}
 
-			$order_id = (int) $request['order_id'];
-
-			$resp = WC_Amazon_Payments_Advanced_API_Legacy::capture( $order_id );
+			$resp = WC_Amazon_Payments_Advanced_API_Legacy::capture( $or->get_id() );
 			if ( is_wp_error( $resp ) ) {
 				return $resp;
 			}
 
 			$order_closed = false;
 
-			$result = WC_Amazon_Payments_Advanced_API_Legacy::handle_payment_capture_response( $resp, $order_id );
+			$result = WC_Amazon_Payments_Advanced_API_Legacy::handle_payment_capture_response( $resp, $or->get_id() );
 			if ( $result ) {
-				$order_closed = WC_Amazon_Payments_Advanced_API_Legacy::close_order_reference( $order_id );
+				$order_closed = WC_Amazon_Payments_Advanced_API_Legacy::close_order_reference( $or->get_id() );
 				$order_closed = ( ! is_wp_error( $order_closed ) && $order_closed );
 			}
 
 			$ret = array(
 				'captured'          => $result,
-				'amazon_capture_id' => get_post_meta( $order_id, 'amazon_capture_id', true ),
+				'amazon_capture_id' => $or->get_meta( 'amazon_capture_id', true, 'edit' ),
 				'order_closed'      => $order_closed,
 			);
 
 			return rest_ensure_response( $ret );
 		} else {
 			$result = array();
-			$charge = wc_apa()->get_gateway()->perform_capture( $order );
+			$charge = wc_apa()->get_gateway()->perform_capture( $or );
 			if ( is_wp_error( $charge ) ) {
 				$result['captured'] = false;
 			} else {
 				$result['captured']         = true;
-				$result['amazon_charge_id'] = WC_Amazon_Payments_Advanced::get_order_charge_id( $order->get_id() );
+				$result['amazon_charge_id'] = WC_Amazon_Payments_Advanced::get_order_charge_id( $or->get_id() );
 			}
 			return rest_ensure_response( $result );
 		}
@@ -522,20 +518,18 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 *                                   WP_REST_Response instance.
 	 */
 	public function refund( $request ) {
-		$order_post = $this->is_valid_order( $request['order_id'] );
-		if ( is_wp_error( $order_post ) ) {
-			return $order_post;
+		$or = $this->is_valid_order( $request['order_id'] );
+		if ( is_wp_error( $or ) ) {
+			return $or;
 		}
 
-		$order   = wc_get_order( $order_post->ID );
-		$version = WC_Amazon_Payments_Advanced::get_order_version( $order_post->ID );
+		$version = WC_Amazon_Payments_Advanced::get_order_version( $or->get_id() );
 		if ( 'v1' === strtolower( $version ) ) {
-			$error = $this->get_missing_capture_id_request_error( $order_post );
+			$error = $this->get_missing_capture_id_request_error( $or );
 			if ( is_wp_error( $error ) ) {
 				return $error;
 			}
 
-			$order_id = (int) $request['order_id'];
 			$amount   = $request['amount'];
 			$reason   = ! empty( $request['reason'] ) ? $request['reason'] : null;
 
@@ -543,12 +537,12 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 				return new WP_Error( 'woocommerce_rest_invalid_order_refund', __( 'Refund amount must be greater than zero.', 'woocommerce-gateway-amazon-payments-advanced' ), 400 );
 			}
 
-			$amazon_capture_id = get_post_meta( $order_id, 'amazon_capture_id', true );
-			$refunded          = WC_Amazon_Payments_Advanced_API_Legacy::refund_payment( $order_id, $amazon_capture_id, $amount, $reason );
+			$amazon_capture_id = $or->get_meta( 'amazon_capture_id', true, 'edit' );
+			$refunded          = WC_Amazon_Payments_Advanced_API_Legacy::refund_payment( $or->get_id(), $amazon_capture_id, $amount, $reason );
 
 			$ret = array( 'refunded' => $refunded );
 			if ( $refunded ) {
-				$ret['amazon_refund_id'] = get_post_meta( $order_id, 'amazon_refund_id', true );
+				$ret['amazon_refund_id'] = $or->get_meta( 'amazon_refund_id', true, 'edit' );
 			}
 
 			return rest_ensure_response( $ret );
@@ -564,7 +558,7 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 
 			$result = array();
 
-			$refund = wc_apa()->get_gateway()->perform_refund( $order, $amount );
+			$refund = wc_apa()->get_gateway()->perform_refund( $or, $amount );
 			if ( is_wp_error( $refund ) ) {
 				$result['refunded'] = false;
 			} else {
@@ -583,7 +577,7 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 * @return null|WP_Error Null if there's no error in the request.
 	 */
 	protected function get_missing_reference_id_request_error( $order_post ) {
-		$ref_id = get_post_meta( $order_post->ID, 'amazon_reference_id', true );
+		$ref_id = $order_post->get_meta( 'amazon_reference_id', true, 'edit' );
 		if ( ! $ref_id ) {
 			return new WP_Error( 'woocommerce_rest_order_missing_amazon_reference_id', __( 'Specified resource does not have Amazon order reference ID', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 400 ) );
 		}
@@ -599,7 +593,7 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 * @return null|WP_Error Null if there's no error in the request.
 	 */
 	protected function get_missing_authorization_id_request_error( $order_post ) {
-		$ref_id = get_post_meta( $order_post->ID, 'amazon_authorization_id', true );
+		$ref_id = $order_post->get_meta( 'amazon_authorization_id', true, 'edit' );
 		if ( ! $ref_id ) {
 			return new WP_Error( 'woocommerce_rest_order_missing_amazon_authorization_id', __( 'Specified resource does not have Amazon authorization ID', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 400 ) );
 		}
@@ -615,7 +609,7 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 * @return null|WP_Error Null if there's no error in the request.
 	 */
 	protected function get_missing_capture_id_request_error( $order_post ) {
-		$ref_id = get_post_meta( $order_post->ID, 'amazon_capture_id', true );
+		$ref_id = $order_post->get_meta( 'amazon_capture_id', true, 'edit' );
 		if ( ! $ref_id ) {
 			return new WP_Error( 'woocommerce_rest_order_missing_amazon_capture_id', __( 'Specified resource does not have Amazon capture ID', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 400 ) );
 		}
@@ -631,14 +625,14 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 * @return WP_Post|WP_Error Post object if it's valid, WP_Error if it's invalid.
 	 */
 	protected function is_valid_order( $order_id ) {
-		$order_post = get_post( (int) $order_id );
+		$or = wc_get_order( (int) $order_id );
 
-		if ( empty( $order_post->post_type ) || $this->post_type !== $order_post->post_type ) {
+		if ( ! ( $or instanceof \WC_Order ) ) {
 			return new WP_Error( 'woocommerce_rest_order_invalid_id', __( 'Invalid order ID.', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 404 ) );
 		}
 
-		$is_valid = 'amazon_payments_advanced' === get_post_meta( $order_post->ID, '_payment_method', true );
+		$is_valid = 'amazon_payments_advanced' === $or->get_payment_method()->id;
 
-		return $is_valid ? $order_post : new WP_Error( 'woocommerce_rest_order_invalid_id', __( 'Invalid order ID.', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 404 ) );
+		return $is_valid ? $or : new WP_Error( 'woocommerce_rest_order_invalid_id', __( 'Invalid order ID.', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 404 ) );
 	}
 }

--- a/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
+++ b/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
@@ -188,11 +188,11 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 				break;
 			case 'delete':
 			case 'edit':
-				$post           = get_post( (int) $request['order_id'] );
+				$post           = wc_get_order( (int) $request['order_id'] );
 				$has_permission = (
-					$post
+					$post instanceof \WC_Order
 					&&
-					wc_rest_check_post_permissions( $this->post_type, $action, $post->ID )
+					wc_rest_check_post_permissions( $this->post_type, $action, $post->get_id() )
 				);
 				break;
 		}

--- a/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
+++ b/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
@@ -428,8 +428,8 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 				return $error;
 			}
 
-			$auth_id  = $or->get_meta( 'amazon_authorization_id', true, true );
-			$resp     = WC_Amazon_Payments_Advanced_API_Legacy::close_authorization( $or->get_id(), $auth_id );
+			$auth_id = $or->get_meta( 'amazon_authorization_id', true, true );
+			$resp    = WC_Amazon_Payments_Advanced_API_Legacy::close_authorization( $or->get_id(), $auth_id );
 			if ( is_wp_error( $resp ) ) {
 				return $resp;
 			}
@@ -530,8 +530,8 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 				return $error;
 			}
 
-			$amount   = $request['amount'];
-			$reason   = ! empty( $request['reason'] ) ? $request['reason'] : null;
+			$amount = $request['amount'];
+			$reason = ! empty( $request['reason'] ) ? $request['reason'] : null;
 
 			if ( 0 > $amount ) {
 				return new WP_Error( 'woocommerce_rest_invalid_order_refund', __( 'Refund amount must be greater than zero.', 'woocommerce-gateway-amazon-payments-advanced' ), 400 );

--- a/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
+++ b/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
@@ -378,14 +378,14 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	protected function authorize_order_v1( $order_id, $authorize_args = array() ) {
 		$authorize_args = wp_parse_args( $authorize_args, array( 'capture_now' => false ) );
 
-		$resp = WC_Amazon_Payments_Advanced_API_Legacy::authorize( $order_id, $authorize_args );
-		if ( is_wp_error( $resp ) ) {
-			return $resp;
+		$response = WC_Amazon_Payments_Advanced_API_Legacy::authorize( $order_id, $authorize_args );
+		if ( is_wp_error( $response ) ) {
+			return $response;
 		}
 
 		$order = wc_get_order( $order_id );
 
-		$result = WC_Amazon_Payments_Advanced_API_Legacy::handle_payment_authorization_response( $resp, $order_id, $authorize_args['capture_now'] );
+		$result = WC_Amazon_Payments_Advanced_API_Legacy::handle_payment_authorization_response( $response, $order_id, $authorize_args['capture_now'] );
 
 		$ret = array(
 			'authorized'              => $result,
@@ -428,14 +428,14 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 				return $error;
 			}
 
-			$auth_id = $order->get_meta( 'amazon_authorization_id', true, true );
-			$resp    = WC_Amazon_Payments_Advanced_API_Legacy::close_authorization( $order->get_id(), $auth_id );
-			if ( is_wp_error( $resp ) ) {
-				return $resp;
+			$authorization_id = $order->get_meta( 'amazon_authorization_id', true, true );
+			$response         = WC_Amazon_Payments_Advanced_API_Legacy::close_authorization( $order->get_id(), $authorization_id );
+			if ( is_wp_error( $response ) ) {
+				return $response;
 			}
 
 			$ret = array(
-				'authorization_closed' => $resp,
+				'authorization_closed' => $response,
 			);
 
 			return rest_ensure_response( $ret );
@@ -474,14 +474,14 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 				return $error;
 			}
 
-			$resp = WC_Amazon_Payments_Advanced_API_Legacy::capture( $order->get_id() );
-			if ( is_wp_error( $resp ) ) {
-				return $resp;
+			$response = WC_Amazon_Payments_Advanced_API_Legacy::capture( $order->get_id() );
+			if ( is_wp_error( $response ) ) {
+				return $response;
 			}
 
 			$order_closed = false;
 
-			$result = WC_Amazon_Payments_Advanced_API_Legacy::handle_payment_capture_response( $resp, $order->get_id() );
+			$result = WC_Amazon_Payments_Advanced_API_Legacy::handle_payment_capture_response( $response, $order->get_id() );
 			if ( $result ) {
 				$order_closed = WC_Amazon_Payments_Advanced_API_Legacy::close_order_reference( $order->get_id() );
 				$order_closed = ( ! is_wp_error( $order_closed ) && $order_closed );

--- a/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
+++ b/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
@@ -577,8 +577,8 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 * @return null|WP_Error Null if there's no error in the request.
 	 */
 	protected function get_missing_reference_id_request_error( $order_post ) {
-		$ref_id = $order_post->get_meta( 'amazon_reference_id', true, 'edit' );
-		if ( ! $ref_id ) {
+		$reference_id = $order_post->get_meta( 'amazon_reference_id', true, 'edit' );
+		if ( ! $reference_id ) {
 			return new WP_Error( 'woocommerce_rest_order_missing_amazon_reference_id', __( 'Specified resource does not have Amazon order reference ID', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 400 ) );
 		}
 
@@ -593,8 +593,8 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 * @return null|WP_Error Null if there's no error in the request.
 	 */
 	protected function get_missing_authorization_id_request_error( $order_post ) {
-		$ref_id = $order_post->get_meta( 'amazon_authorization_id', true, 'edit' );
-		if ( ! $ref_id ) {
+		$reference_id = $order_post->get_meta( 'amazon_authorization_id', true, 'edit' );
+		if ( ! $reference_id ) {
 			return new WP_Error( 'woocommerce_rest_order_missing_amazon_authorization_id', __( 'Specified resource does not have Amazon authorization ID', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 400 ) );
 		}
 
@@ -609,8 +609,8 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	 * @return null|WP_Error Null if there's no error in the request.
 	 */
 	protected function get_missing_capture_id_request_error( $order_post ) {
-		$ref_id = $order_post->get_meta( 'amazon_capture_id', true, 'edit' );
-		if ( ! $ref_id ) {
+		$reference_id = $order_post->get_meta( 'amazon_capture_id', true, 'edit' );
+		if ( ! $reference_id ) {
 			return new WP_Error( 'woocommerce_rest_order_missing_amazon_capture_id', __( 'Specified resource does not have Amazon capture ID', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 400 ) );
 		}
 

--- a/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
+++ b/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
@@ -188,11 +188,11 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 				break;
 			case 'delete':
 			case 'edit':
-				$post           = wc_get_order( (int) $request['order_id'] );
+				$order          = wc_get_order( (int) $request['order_id'] );
 				$has_permission = (
-					$post instanceof \WC_Order
+					$order instanceof \WC_Order
 					&&
-					wc_rest_check_post_permissions( $this->post_type, $action, $post->get_id() )
+					wc_rest_check_post_permissions( $this->post_type, $action, $order->get_id() )
 				);
 				break;
 		}
@@ -572,12 +572,12 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	/**
 	 * Get error from request when no reference_id from specified order.
 	 *
-	 * @param WP_Post $order_post WP Post object.
+	 * @param WC_Order $order Order object.
 	 *
 	 * @return null|WP_Error Null if there's no error in the request.
 	 */
-	protected function get_missing_reference_id_request_error( $order_post ) {
-		$reference_id = $order_post->get_meta( 'amazon_reference_id', true, 'edit' );
+	protected function get_missing_reference_id_request_error( $order ) {
+		$reference_id = $order->get_meta( 'amazon_reference_id', true, 'edit' );
 		if ( ! $reference_id ) {
 			return new WP_Error( 'woocommerce_rest_order_missing_amazon_reference_id', __( 'Specified resource does not have Amazon order reference ID', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 400 ) );
 		}
@@ -588,12 +588,12 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	/**
 	 * Get error from request when no authorization_id from specified order.
 	 *
-	 * @param WP_Post $order_post WP Post object.
+	 * @param WC_Order $order Order object.
 	 *
 	 * @return null|WP_Error Null if there's no error in the request.
 	 */
-	protected function get_missing_authorization_id_request_error( $order_post ) {
-		$reference_id = $order_post->get_meta( 'amazon_authorization_id', true, 'edit' );
+	protected function get_missing_authorization_id_request_error( $order ) {
+		$reference_id = $order->get_meta( 'amazon_authorization_id', true, 'edit' );
 		if ( ! $reference_id ) {
 			return new WP_Error( 'woocommerce_rest_order_missing_amazon_authorization_id', __( 'Specified resource does not have Amazon authorization ID', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 400 ) );
 		}
@@ -604,12 +604,12 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 	/**
 	 * Get error from request when no capture_id from specified order.
 	 *
-	 * @param WP_Post $order_post WP Post object.
+	 * @param WC_Order $order Order object.
 	 *
 	 * @return null|WP_Error Null if there's no error in the request.
 	 */
-	protected function get_missing_capture_id_request_error( $order_post ) {
-		$reference_id = $order_post->get_meta( 'amazon_capture_id', true, 'edit' );
+	protected function get_missing_capture_id_request_error( $order ) {
+		$reference_id = $order->get_meta( 'amazon_capture_id', true, 'edit' );
 		if ( ! $reference_id ) {
 			return new WP_Error( 'woocommerce_rest_order_missing_amazon_capture_id', __( 'Specified resource does not have Amazon capture ID', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 400 ) );
 		}

--- a/includes/class-wc-amazon-payments-advanced-utils.php
+++ b/includes/class-wc-amazon-payments-advanced-utils.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Utils class.
+ *
+ * @package WC_Gateway_Amazon_Pay
+ */
+
+/**
+ * Implement Helper methods.
+ */
+class WC_Amazon_Payments_Advanced_Utils {
+
+	/**
+	 * Returns the edit order's screen id.
+	 *
+	 * Takes into consideration if HPOS is enabled or not.
+	 *
+	 * @return string
+	 */
+	public static function get_edit_order_screen_id() {
+		if ( ! function_exists( 'wc_get_container' ) || ! class_exists( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
+			return 'shop_order';
+		}
+
+		return wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+		? wc_get_page_screen_id( 'shop-order' )
+		: 'shop_order';
+	}
+}

--- a/includes/class-wc-gateway-amazon-payments-advanced-privacy.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-privacy.php
@@ -87,23 +87,23 @@ class WC_Gateway_Amazon_Payments_Advanced_Privacy extends WC_Abstract_Privacy {
 					'data'        => array(
 						array(
 							'name'  => __( 'Amazon Pay authorization id', 'woocommerce-gateway-amazon-payments-advanced' ),
-							'value' => get_post_meta( $order->get_id(), 'amazon_authorization_id', true ),
+							'value' => $order->get_meta( 'amazon_authorization_id', true, 'edit' ),
 						),
 						array(
 							'name'  => __( 'Amazon Pay capture id', 'woocommerce-gateway-amazon-payments-advanced' ),
-							'value' => get_post_meta( $order->get_id(), 'amazon_capture_id', true ),
+							'value' => $order->get_meta( 'amazon_capture_id', true, 'edit' ),
 						),
 						array(
 							'name'  => __( 'Amazon Pay reference id', 'woocommerce-gateway-amazon-payments-advanced' ),
-							'value' => get_post_meta( $order->get_id(), 'amazon_reference_id', true ),
+							'value' => $order->get_meta( 'amazon_reference_id', true, 'edit' ),
 						),
 						array(
 							'name'  => __( 'Amazon Pay refunds id', 'woocommerce-gateway-amazon-payments-advanced' ),
-							'value' => wp_json_encode( get_post_meta( $order->get_id(), 'amazon_refund_id', false ) ),
+							'value' => wp_json_encode( $order->get_meta( 'amazon_refund_id', false, 'edit' ) ),
 						),
 						array(
 							'name'  => __( 'Amazon subscription token', 'woocommerce-gateway-amazon-payments-advanced' ),
-							'value' => get_post_meta( $order->get_id(), 'amazon_billing_agreement_id', true ),
+							'value' => $order->get_meta( 'amazon_billing_agreement_id', true, 'edit' ),
 						),
 						array(
 							'name'  => __( 'Amazon Pay charge permission id', 'woocommerce-gateway-amazon-payments-advanced' ),
@@ -172,7 +172,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Privacy extends WC_Abstract_Privacy {
 					'data'        => array(
 						array(
 							'name'  => __( 'Amazon subscription token', 'woocommerce-gateway-amazon-payments-advanced' ),
-							'value' => get_post_meta( $subscription->get_id(), 'amazon_billing_agreement_id', true ),
+							'value' => $subscription->get_meta( 'amazon_billing_agreement_id', true, 'true' ),
 						),
 						array(
 							'name'  => __( 'Amazon Pay charge permission id', 'woocommerce-gateway-amazon-payments-advanced' ),
@@ -272,7 +272,6 @@ class WC_Gateway_Amazon_Payments_Advanced_Privacy extends WC_Abstract_Privacy {
 	 * @return array
 	 */
 	protected function maybe_handle_order( $order ) {
-		$order_id       = $order->get_id();
 		$meta_to_delete = array(
 			'amazon_authorization_id',
 			'amazon_authorization_state',
@@ -292,13 +291,15 @@ class WC_Gateway_Amazon_Payments_Advanced_Privacy extends WC_Abstract_Privacy {
 
 		$deleted = false;
 		foreach ( $meta_to_delete as $key ) {
-			$meta_value = get_post_meta( $order_id, $key, true );
+			$meta_value = $order->get_meta( $key, true, 'edit' );
 			if ( empty( $meta_value ) ) {
 				continue;
 			}
-			delete_post_meta( $order_id, $key );
+			$order->delete_meta_data( $key );
 			$deleted = true;
 		}
+
+		$order->save();
 
 		$messages = array();
 		if ( $deleted ) {
@@ -310,7 +311,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Privacy extends WC_Abstract_Privacy {
 				$type = __( 'refund', 'woocommerce-gateway-amazon-payments-advanced' );
 			}
 			/* translators: 1) Object ID 2) Object Type. */
-			$messages = array( sprintf( __( 'Amazon Payments Advanced data within %2$s %1$s has been removed.', 'woocommerce-gateway-amazon-payments-advanced' ), $order_id, $type ) );
+			$messages = array( sprintf( __( 'Amazon Payments Advanced data within %2$s %1$s has been removed.', 'woocommerce-gateway-amazon-payments-advanced' ), $order->get_id(), $type ) );
 		}
 
 		return array( $deleted, false, $messages );

--- a/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
+++ b/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
@@ -471,13 +471,13 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return string|bool Returns false if failed
 	 */
 	public static function get_reference_state( $order_id, $id ) {
-		$or = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
 
-		if ( ! ( $or instanceof \WC_Order ) ) {
+		if ( ! ( $order instanceof \WC_Order ) ) {
 			return false;
 		}
 
-		$state = $or->get_meta( 'amazon_reference_state', true, 'edit' );
+		$state = $order->get_meta( 'amazon_reference_state', true, 'edit' );
 		if ( $state ) {
 			return $state;
 		}
@@ -496,8 +496,8 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 		$state = (string) $response->GetOrderReferenceDetailsResult->OrderReferenceDetails->OrderReferenceStatus->State;
 		// @codingStandardsIgnoreEnd
 
-		$or->update_meta_data( 'amazon_reference_state', $state );
-		$or->save();
+		$order->update_meta_data( 'amazon_reference_state', $state );
+		$order->save();
 
 		return $state;
 	}
@@ -593,29 +593,29 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	public static function get_order_ref_state( $order_id, $state = 'amazon_reference_state' ) {
 		$ret_state = '';
 
-		$or = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
 
-		if ( ! ( $or instanceof \WC_order ) ) {
+		if ( ! ( $order instanceof \WC_order ) ) {
 			return $ret_state;
 		}
 
 		switch ( $state ) {
 			case 'amazon_reference_state':
-				$ref_id = $or->get_meta( 'amazon_reference_id', true, 'edit' );
+				$ref_id = $order->get_meta( 'amazon_reference_id', true, 'edit' );
 				if ( $ref_id ) {
 					$ret_state = self::get_reference_state( $order_id, $ref_id );
 				}
 				break;
 
 			case 'amazon_authorization_state':
-				$ref_id = $or->get_meta( 'amazon_authorization_id', true, 'edit' );
+				$ref_id = $order->get_meta( 'amazon_authorization_id', true, 'edit' );
 				if ( $ref_id ) {
 					$ret_state = self::get_authorization_state( $order_id, $ref_id );
 				}
 				break;
 
 			case 'amazon_capture_state':
-				$ref_id = $or->get_meta( 'amazon_capture_id', true, 'edit' );
+				$ref_id = $order->get_meta( 'amazon_capture_id', true, 'edit' );
 				if ( $ref_id ) {
 					$ret_state = self::get_capture_state( $order_id, $ref_id );
 				}

--- a/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
+++ b/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
@@ -471,7 +471,13 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return string|bool Returns false if failed
 	 */
 	public static function get_reference_state( $order_id, $id ) {
-		$state = get_post_meta( $order_id, 'amazon_reference_state', true );
+		$or = wc_get_order( $order_id );
+
+		if ( ! ( $or instanceof \WC_Order ) ) {
+			return false;
+		}
+
+		$state = $or->get_meta( 'amazon_reference_state', true, 'edit' );
 		if ( $state ) {
 			return $state;
 		}
@@ -490,7 +496,8 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 		$state = (string) $response->GetOrderReferenceDetailsResult->OrderReferenceDetails->OrderReferenceStatus->State;
 		// @codingStandardsIgnoreEnd
 
-		update_post_meta( $order_id, 'amazon_reference_state', $state );
+		$or->update_meta_data( 'amazon_reference_state', $state );
+		$or->save();
 
 		return $state;
 	}
@@ -574,23 +581,29 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	public static function get_order_ref_state( $order_id, $state = 'amazon_reference_state' ) {
 		$ret_state = '';
 
+		$or = wc_get_order( $order_id );
+
+		if ( ! ( $or instanceof \WC_order ) ) {
+			return $ret_state;
+		}
+
 		switch ( $state ) {
 			case 'amazon_reference_state':
-				$ref_id = get_post_meta( $order_id, 'amazon_reference_id', true );
+				$ref_id = $or->get_meta( 'amazon_reference_id', true, 'edit' );
 				if ( $ref_id ) {
 					$ret_state = self::get_reference_state( $order_id, $ref_id );
 				}
 				break;
 
 			case 'amazon_authorization_state':
-				$ref_id = get_post_meta( $order_id, 'amazon_authorization_id', true );
+				$ref_id = $or->get_meta( 'amazon_authorization_id', true, 'edit' );
 				if ( $ref_id ) {
 					$ret_state = self::get_authorization_state( $order_id, $ref_id );
 				}
 				break;
 
 			case 'amazon_capture_state':
-				$ref_id = get_post_meta( $order_id, 'amazon_capture_id', true );
+				$ref_id = $or->get_meta( 'amazon_capture_id', true, 'edit' );
 				if ( $ref_id ) {
 					$ret_state = self::get_capture_state( $order_id, $ref_id );
 				}

--- a/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
+++ b/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
@@ -511,7 +511,12 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return string|bool Returns false if failed.
 	 */
 	public static function get_authorization_state( $order_id, $id ) {
-		$state = get_post_meta( $order_id, 'amazon_authorization_state', true );
+		$order = wc_get_order( $order_id );
+		if ( ! ( $order instanceof \WC_Order ) ) {
+			return false;
+		}
+
+		$state = $order->get_meta( 'amazon_authorization_state', true, 'edit' );
 		if ( $state ) {
 			return $state;
 		}
@@ -530,7 +535,8 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 		$state = (string) $response->GetAuthorizationDetailsResult->AuthorizationDetails->AuthorizationStatus->State;
 		// @codingStandardsIgnoreEnd
 
-		update_post_meta( $order_id, 'amazon_authorization_state', $state );
+		$order->update_meta_data( 'amazon_authorization_state', $state );
+		$order->save();
 
 		self::update_order_billing_address( $order_id, self::get_billing_address_from_response( $response ) );
 
@@ -546,7 +552,12 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return string|bool Returns false if failed.
 	 */
 	public static function get_capture_state( $order_id, $id ) {
-		$state = get_post_meta( $order_id, 'amazon_capture_state', true );
+		$order = wc_get_order( $order_id );
+		if ( ! ( $order instanceof \WC_Order ) ) {
+			return false;
+		}
+
+		$state = $order->get_meta( 'amazon_capture_state', true, 'edit' );
 		if ( $state ) {
 			return $state;
 		}
@@ -565,7 +576,8 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 		$state = (string) $response->GetCaptureDetailsResult->CaptureDetails->CaptureStatus->State;
 		// @codingStandardsIgnoreEnd
 
-		update_post_meta( $order_id, 'amazon_capture_state', $state );
+		$order->update_meta_data( 'amazon_capture_state', $state );
+		$order->save();
 
 		return $state;
 	}
@@ -632,27 +644,27 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 
 		$order_id = wc_apa_get_order_prop( $order, 'id' );
 
-		update_post_meta( $order_id, 'amazon_authorization_id', $auth_id );
+		$order->update_meta_data( 'amazon_authorization_id', $auth_id );
 
 		$authorization_status = self::get_auth_state_from_reponse( $ipn_payload );
 		switch ( $authorization_status ) {
 			case 'open':
 				// Updating amazon_authorization_state.
-				update_post_meta( $order_id, 'amazon_authorization_state', 'Open' );
+				$order->update_meta_data( 'amazon_authorization_state', 'Open' );
 				// Delete amazon_timed_out_transaction meta.
-				delete_post_meta( $order_id, 'amazon_timed_out_transaction' );
+				$order->delete_meta_data( 'amazon_timed_out_transaction' );
 				/* translators: 1) Auth ID. */
 				$order->add_order_note( sprintf( __( 'Authorized (Auth ID: %s)', 'woocommerce-gateway-amazon-payments-advanced' ), $auth_id ) );
 				$order->add_order_note( __( 'Amazon order opened. Use the "Amazon Pay" box to authorize and/or capture payment. Authorized payments must be captured within 7 days.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 				break;
 			case 'closed':
-				update_post_meta( $order_id, 'amazon_capture_id', str_replace( '-A', '-C', $auth_id ) );
-				update_post_meta( $order_id, 'amazon_authorization_state', $authorization_status );
+				$order->update_meta_data( 'amazon_capture_id', str_replace( '-A', '-C', $auth_id ) );
+				$order->update_meta_data( 'amazon_authorization_state', $authorization_status );
 				/* translators: 1) Auth ID. */
 				$order->add_order_note( sprintf( __( 'Captured (Auth ID: %s)', 'woocommerce-gateway-amazon-payments-advanced' ), str_replace( '-A', '-C', $auth_id ) ) );
 				$order->payment_complete();
 				// Delete amazon_timed_out_transaction meta.
-				delete_post_meta( $order_id, 'amazon_timed_out_transaction' );
+				$order->delete_meta_data( 'amazon_timed_out_transaction' );
 				// Close order reference.
 				self::close_order_reference( $order_id );
 				break;
@@ -660,7 +672,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 				$state_reason_code = self::get_auth_state_reason_code_from_response( $ipn_payload );
 				if ( 'InvalidPaymentMethod' === $state_reason_code ) {
 					// Soft Decline.
-					update_post_meta( $order_id, 'amazon_authorization_state', 'Suspended' );
+					$order->update_meta_data( 'amazon_authorization_state', 'Suspended' );
 					$order->add_order_note( sprintf( __( 'Amazon Order Suspended. Email sent to customer to change its payment method.', 'woocommerce-gateway-amazon-payments-advanced' ), $auth_id ) );
 					$subject = __( 'Please update your payment information', 'woocommerce-gateway-amazon-payments-advanced' );
 					$message = wc_get_template_html( 'emails/legacy/soft-decline.php', array( 'order_id' => $order_id ), '', plugin_dir_path( __DIR__ ) . '/templates/' );
@@ -692,11 +704,13 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 						// Cancel amazon order.
 						self::cancel_order_reference( $order_id );
 					}
-					$order->save();
 				}
 
 				break;
 		}
+
+		$order->save();
+
 		return $authorization_status;
 	}
 
@@ -713,7 +727,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 
 		$order_id = wc_apa_get_order_prop( $order, 'id' );
 
-		update_post_meta( $order_id, 'amazon_authorization_id', $auth_id );
+		$order->update_meta_data( 'amazon_authorization_id', $auth_id );
 
 		$authorization_status = self::get_auth_state_from_reponse( $response );
 		wc_apa()->log( sprintf( 'Found authorization status of %s on pending synchronous payment', $authorization_status ) );
@@ -721,21 +735,21 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 		switch ( $authorization_status ) {
 			case 'open':
 				// Updating amazon_authorization_state.
-				update_post_meta( $order_id, 'amazon_authorization_state', 'Open' );
+				$order->update_meta_data( 'amazon_authorization_state', 'Open' );
 				// Delete amazon_timed_out_transaction meta.
-				delete_post_meta( $order_id, 'amazon_timed_out_transaction' );
+				$order->delete_meta_data( 'amazon_timed_out_transaction' );
 				/* translators: 1) Auth ID. */
 				$order->add_order_note( sprintf( __( 'Authorized (Auth ID: %s)', 'woocommerce-gateway-amazon-payments-advanced' ), $auth_id ) );
 				$order->add_order_note( __( 'Amazon order opened. Use the "Amazon Pay" box to authorize and/or capture payment. Authorized payments must be captured within 7 days.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 				break;
 			case 'closed':
-				update_post_meta( $order_id, 'amazon_capture_id', str_replace( '-A', '-C', $auth_id ) );
-				update_post_meta( $order_id, 'amazon_authorization_state', $authorization_status );
+				$order->update_meta_data( 'amazon_capture_id', str_replace( '-A', '-C', $auth_id ) );
+				$order->update_meta_data( 'amazon_authorization_state', $authorization_status );
 				/* translators: 1) Auth ID. */
 				$order->add_order_note( sprintf( __( 'Captured (Auth ID: %s)', 'woocommerce-gateway-amazon-payments-advanced' ), str_replace( '-A', '-C', $auth_id ) ) );
 				$order->payment_complete();
 				// Delete amazon_timed_out_transaction meta.
-				delete_post_meta( $order_id, 'amazon_timed_out_transaction' );
+				$order->delete_meta_data( 'amazon_timed_out_transaction' );
 				// Close order reference.
 				self::close_order_reference( $order_id );
 				break;
@@ -743,7 +757,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 				$state_reason_code = self::get_auth_state_reason_code_from_response( $response );
 				if ( 'InvalidPaymentMethod' === $state_reason_code ) {
 					// Soft Decline.
-					update_post_meta( $order_id, 'amazon_authorization_state', 'Suspended' );
+					$order->update_meta_data( 'amazon_authorization_state', 'Suspended' );
 					$order->add_order_note( sprintf( __( 'Amazon Order Suspended. Email sent to customer to change its payment method.', 'woocommerce-gateway-amazon-payments-advanced' ), $auth_id ) );
 					$subject = __( 'Please update your payment information', 'woocommerce-gateway-amazon-payments-advanced' );
 					$message = wc_get_template_html( 'emails/legacy/soft-decline.php', array( 'order_id' => $order_id ), '', plugin_dir_path( __DIR__ ) . '/templates/' );
@@ -772,7 +786,6 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 						// Cancel amazon order.
 						self::cancel_order_reference( $order_id );
 					}
-					$order->save();
 				}
 				break;
 			case 'pending':
@@ -787,6 +800,9 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 				}
 				break;
 		}
+
+		$order->save();
+
 		return $authorization_status;
 	}
 
@@ -798,7 +814,8 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return string
 	 */
 	public static function get_order_language( $order_id ) {
-		return get_post_meta( $order_id, 'amazon_order_language', true );
+		$order = wc_get_order( $order_id );
+		return $order instanceof \WC_Order ? $order->get_meta( 'amazon_order_language', true, 'edit' ) : '';
 	}
 
 	/**
@@ -832,7 +849,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 		);
 
 		if ( empty( $args['amazon_reference_id'] ) ) {
-			$args['amazon_reference_id'] = get_post_meta( $order_id, 'amazon_reference_id', true );
+			$args['amazon_reference_id'] = $order->get_meta( 'amazon_reference_id', true, 'edit' );
 		}
 
 		if ( ! $args['amazon_reference_id'] ) {
@@ -994,11 +1011,10 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 			return new WP_Error( 'invalid_order', __( 'Order is not paid via Amazon Pay.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
 
-		$order_id = wc_apa_get_order_prop( $order, 'id' );
-		$args     = wp_parse_args(
+		$args = wp_parse_args(
 			$args,
 			array(
-				'amazon_reference_id' => get_post_meta( $order_id, 'amazon_billing_agreement_id', true ),
+				'amazon_reference_id' => $order->get_meta( 'amazon_billing_agreement_id', true, 'edit' ),
 				'capture_now'         => false,
 			)
 		);
@@ -1088,6 +1104,10 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return bool Returns true if succeed.
 	 */
 	public static function update_order_from_authorize_response( $order, $response, $capture_now = false ) {
+		if ( ! ( $order instanceof \WC_Order ) ) {
+			return false;
+		}
+
 		$auth_id = self::get_auth_id_from_response( $response );
 		if ( ! $auth_id ) {
 			return false;
@@ -1096,12 +1116,15 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 
 		$order_id = wc_apa_get_order_prop( $order, 'id' );
 
-		update_post_meta( $order_id, 'amazon_authorization_id', $auth_id );
+		$order->update_meta_data( 'amazon_authorization_id', $auth_id );
 
 		// This is true only on AuthorizeOnBillingAgreement, for the recurring payments.
 		if ( $amazon_reference_id ) {
-			update_post_meta( $order_id, 'amazon_reference_id', $amazon_reference_id );
+			$order->update_meta_data( 'amazon_reference_id', $amazon_reference_id );
 		}
+
+		$order->save();
+
 		self::update_order_billing_address( $order_id, self::get_billing_address_from_response( $response ) );
 
 		$state = self::get_auth_state_from_reponse( $response );
@@ -1113,7 +1136,8 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 		}
 
 		if ( $capture_now ) {
-			update_post_meta( $order_id, 'amazon_capture_id', str_replace( '-A', '-C', $auth_id ) );
+			$order->update_meta_data( 'amazon_capture_id', str_replace( '-A', '-C', $auth_id ) );
+			$order->save();
 
 			/* translators: 1) Auth ID. */
 			$order->add_order_note( sprintf( __( 'Captured (Auth ID: %s)', 'woocommerce-gateway-amazon-payments-advanced' ), str_replace( '-A', '-C', $auth_id ) ) );
@@ -1147,7 +1171,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 			return new WP_Error( 'invalid_order', __( 'Order is not paid via Amazon Pay', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
 
-		$amazon_reference_id = get_post_meta( $order_id, 'amazon_reference_id', true );
+		$amazon_reference_id = $order->get_meta( 'amazon_reference_id', true, 'edit' );
 		if ( ! $amazon_reference_id ) {
 			return new WP_Error( 'order_missing_amazon_reference_id', __( 'Order missing Amazon reference ID', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
@@ -1312,6 +1336,11 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return bool
 	 */
 	public static function update_order_billing_address( $order_id, $address = array() ) {
+		$order = wc_get_order( $order_id );
+		if ( ! ( $order instanceof \WC_Order ) ) {
+			return false;
+		}
+
 		// Format address and map to WC fields.
 		$address_lines = array();
 
@@ -1326,31 +1355,33 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 		}
 
 		if ( 3 === count( $address_lines ) ) {
-			update_post_meta( $order_id, '_billing_company', $address_lines[0] );
-			update_post_meta( $order_id, '_billing_address_1', $address_lines[1] );
-			update_post_meta( $order_id, '_billing_address_2', $address_lines[2] );
+			$order->update_meta_data( '_billing_company', $address_lines[0] );
+			$order->update_meta_data( '_billing_address_1', $address_lines[1] );
+			$order->update_meta_data( '_billing_address_2', $address_lines[2] );
 		} elseif ( 2 === count( $address_lines ) ) {
-			update_post_meta( $order_id, '_billing_address_1', $address_lines[0] );
-			update_post_meta( $order_id, '_billing_address_2', $address_lines[1] );
+			$order->update_meta_data( '_billing_address_1', $address_lines[0] );
+			$order->update_meta_data( '_billing_address_2', $address_lines[1] );
 		} elseif ( count( $address_lines ) ) {
-			update_post_meta( $order_id, '_billing_address_1', $address_lines[0] );
+			$order->update_meta_data( '_billing_address_1', $address_lines[0] );
 		}
 
 		if ( isset( $address['City'] ) ) {
-			update_post_meta( $order_id, '_billing_city', $address['City'] );
+			$order->update_meta_data( '_billing_city', $address['City'] );
 		}
 
 		if ( isset( $address['PostalCode'] ) ) {
-			update_post_meta( $order_id, '_billing_postcode', $address['PostalCode'] );
+			$order->update_meta_data( '_billing_postcode', $address['PostalCode'] );
 		}
 
 		if ( isset( $address['StateOrRegion'] ) ) {
-			update_post_meta( $order_id, '_billing_state', $address['StateOrRegion'] );
+			$order->update_meta_data( '_billing_state', $address['StateOrRegion'] );
 		}
 
 		if ( isset( $address['CountryCode'] ) ) {
-			update_post_meta( $order_id, '_billing_country', $address['CountryCode'] );
+			$order->update_meta_data( '_billing_country', $address['CountryCode'] );
 		}
+
+		$order->save();
 
 		return true;
 	}
@@ -1366,15 +1397,15 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 */
 	public static function handle_async_ipn_order_reference_payload( $ipn_payload, $order ) {
 		$order                 = is_int( $order ) ? wc_get_order( $order ) : $order;
-		$order_id              = wc_apa_get_order_prop( $order, 'id' );
 		$order_reference_state = (string) $ipn_payload->OrderReference->OrderReferenceStatus->State; // phpcs:ignore WordPress.NamingConventions
 
-		update_post_meta( $order_id, 'amazon_reference_state', $order_reference_state );
+		$order->update_meta_data( 'amazon_reference_state', $order_reference_state );
+		$order->save();
 
 		if ( 'open' === strtolower( $order_reference_state ) ) {
 			// New Async Auth.
 			$order->add_order_note( __( 'Async Authorized attempt.', 'woocommerce-gateway-amazon-payments-advanced' ) );
-			$amazon_reference_id = get_post_meta( $order_id, 'amazon_reference_id', true );
+			$amazon_reference_id = $order->get_meta( 'amazon_reference_id', true, 'edit' );
 			do_action( 'wc_amazon_async_authorize', $order, $amazon_reference_id );
 		}
 	}
@@ -1389,8 +1420,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return bool|WP_Error Return true when succeed. Otherwise WP_Error is returned
 	 */
 	public static function close_order_reference( $order ) {
-		$order    = wc_get_order( $order );
-		$order_id = wc_apa_get_order_prop( $order, 'id' );
+		$order = wc_get_order( $order );
 		if ( ! $order ) {
 			return new WP_Error( 'invalid_order', __( 'Invalid order ID', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
@@ -1399,12 +1429,12 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 			return new WP_Error( 'invalid_order', __( 'Order is not paid via Amazon Pay', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
 
-		$amazon_reference_id = get_post_meta( $order_id, 'amazon_reference_id', true );
+		$amazon_reference_id = $order->get_meta( 'amazon_reference_id', true, 'edit' );
 		if ( ! $amazon_reference_id ) {
 			return new WP_Error( 'order_missing_amazon_reference_id', __( 'Order missing Amazon reference ID', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
 
-		$amazon_billing_agreement_id = get_post_meta( $order_id, 'amazon_billing_agreement_id', true );
+		$amazon_billing_agreement_id = $order->get_meta( 'amazon_billing_agreement_id', true, 'edit' );
 		if ( $amazon_billing_agreement_id ) {
 			// If it has a billing agreement Amazon close it on auth, no need to close the order.
 			// https://developer.amazon.com/docs/amazon-pay-api/order-reference-states-and-reason-codes.html .
@@ -1463,7 +1493,8 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 				$code = isset( $response->Error->Code ) ? (string) $response->Error->Code : 'amazon_error_response';
 				$ret = new WP_Error( $code, (string) $response->Error->Message );
 			} else {
-				delete_post_meta( $order_id, 'amazon_authorization_id' );
+				$order->delete_meta_data( 'amazon_authorization_id' );
+				$order->save();
 
 				$order->add_order_note( sprintf( __( 'Authorization closed (Auth ID: %s)', 'woocommerce-gateway-amazon-payments-advanced' ), $amazon_authorization_id ) );
 				$ret = true;
@@ -1489,8 +1520,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return bool|object|WP_Error
 	 */
 	public static function capture( $order, $args = array() ) {
-		$order    = wc_get_order( $order );
-		$order_id = wc_apa_get_order_prop( $order, 'id' );
+		$order = wc_get_order( $order );
 		if ( ! $order ) {
 			return new WP_Error( 'invalid_order', __( 'Invalid order ID', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
@@ -1502,7 +1532,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 		$args = wp_parse_args(
 			$args,
 			array(
-				'amazon_authorization_id' => get_post_meta( $order_id, 'amazon_authorization_id', true ),
+				'amazon_authorization_id' => $order->get_meta( 'amazon_authorization_id', true, 'edit' ),
 				'capture_now'             => false,
 			)
 		);
@@ -1600,16 +1630,16 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	public static function update_order_from_capture_response( $order, $response ) {
 		// @codingStandardsIgnoreStart
 		$capture_id = (string) $response->CaptureResult->CaptureDetails->AmazonCaptureId;
-		$order_id   = wc_apa_get_order_prop( $order, 'id' );
 		if ( ! $capture_id ) {
 			return false;
 		}
 		// @codingStandardsIgnoreEnd
 
-				/* translators: 1) Capture ID. */
+		/* translators: 1) Capture ID. */
 		$order->add_order_note( sprintf( __( 'Capture Attempted (Capture ID: %s)', 'woocommerce-gateway-amazon-payments-advanced' ), $capture_id ) );
 
-		update_post_meta( $order_id, 'amazon_capture_id', $capture_id );
+		$order->update_meta_data( 'amazon_capture_id', $capture_id );
+		$order->save();
 
 		$order->payment_complete();
 
@@ -1627,7 +1657,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return bool Returns true if succeed.
 	 */
 	public static function refund_payment( $order_id, $capture_id, $amount, $note ) {
-		$order = new WC_Order( $order_id );
+		$order = wc_get_order( $order_id );
 		$ret   = false;
 
 		if ( 'amazon_payments_advanced' === wc_apa_get_order_prop( $order, 'payment_method' ) ) {
@@ -1665,7 +1695,8 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 				/* Translators: 1: refund amount, 2: refund note */
 				$order->add_order_note( sprintf( __( 'Refunded %1$s (%2$s)', 'woocommerce-gateway-amazon-payments-advanced' ), wc_price( $amount ), $note ) );
 
-				add_post_meta( $order_id, 'amazon_refund_id', $refund_id );
+				$order->update_meta_data( 'amazon_refund_id', $refund_id );
+				$order->save();
 
 				$ret = true;
 			}
@@ -1683,22 +1714,37 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return int Order ID.
 	 */
 	public static function get_order_id_from_reference_id( $reference_id ) {
-		global $wpdb;
+		add_filter(
+			'woocommerce_order_data_store_cpt_get_orders_query',
+			function ( $query, $query_vars ) {
+				if ( empty( $query_vars['amazon_reference_id'] ) ) {
+					return $query;
+				}
 
-		$order_id = $wpdb->get_var(
-			$wpdb->prepare(
-				"
-			SELECT post_id
-			FROM $wpdb->postmeta
-			WHERE meta_key = 'amazon_reference_id'
-			AND meta_value = %s
-		",
-				$reference_id
+				if ( empty( $query['meta_query'] ) || ! is_array( $query['meta_query'] ) ) {
+					$query['meta_query'] = array(); //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				}
+
+				$query['meta_query'][] = array( //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'key'   => 'amazon_reference_id',
+					'value' => esc_attr( $query_vars['amazon_reference_id'] ),
+				);
+
+				return $query;
+			},
+			10,
+			2
+		);
+
+		$orders = wc_get_orders(
+			array(
+				'amazon_reference_id' => $reference_id,
+				'limit'               => 1,
 			)
 		);
 
-		if ( ! is_wp_error( $order_id ) ) {
-			return $order_id;
+		if ( ! empty( $orders->orders[0] ) && $orders->orders[0] instanceof \WC_Order ) {
+			return $orders->orders[0]->get_id();
 		}
 
 		return 0;

--- a/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
+++ b/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
@@ -591,38 +591,38 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return string Reference state.
 	 */
 	public static function get_order_ref_state( $order_id, $state = 'amazon_reference_state' ) {
-		$ret_state = '';
+		$reference_state = '';
 
 		$order = wc_get_order( $order_id );
 
 		if ( ! ( $order instanceof \WC_order ) ) {
-			return $ret_state;
+			return $reference_state;
 		}
 
 		switch ( $state ) {
 			case 'amazon_reference_state':
-				$ref_id = $order->get_meta( 'amazon_reference_id', true, 'edit' );
-				if ( $ref_id ) {
-					$ret_state = self::get_reference_state( $order_id, $ref_id );
+				$reference_id = $order->get_meta( 'amazon_reference_id', true, 'edit' );
+				if ( $reference_id ) {
+					$reference_state = self::get_reference_state( $order_id, $reference_id );
 				}
 				break;
 
 			case 'amazon_authorization_state':
-				$ref_id = $order->get_meta( 'amazon_authorization_id', true, 'edit' );
-				if ( $ref_id ) {
-					$ret_state = self::get_authorization_state( $order_id, $ref_id );
+				$reference_id = $order->get_meta( 'amazon_authorization_id', true, 'edit' );
+				if ( $reference_id ) {
+					$reference_state = self::get_authorization_state( $order_id, $reference_id );
 				}
 				break;
 
 			case 'amazon_capture_state':
-				$ref_id = $order->get_meta( 'amazon_capture_id', true, 'edit' );
-				if ( $ref_id ) {
-					$ret_state = self::get_capture_state( $order_id, $ref_id );
+				$reference_id = $order->get_meta( 'amazon_capture_id', true, 'edit' );
+				if ( $reference_id ) {
+					$reference_state = self::get_capture_state( $order_id, $reference_id );
 				}
 				break;
 		}
 
-		return $ret_state;
+		return $reference_state;
 	}
 
 	/**

--- a/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
+++ b/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
@@ -1078,6 +1078,10 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	public static function handle_payment_authorization_response( $response, $order, $capture_now, $auth_method = null ) {
 		$order = wc_get_order( $order );
 
+		if ( ! ( $order instanceof \WC_Order ) ) {
+			return false;
+		}
+
 		if ( null !== $auth_method ) {
 			_deprecated_function( 'WC_Amazon_Payments_Advanced_API_Legacy::handle_payment_authorization_response', '1.6.0', 'Parameter auth_method is not used anymore' );
 		}
@@ -1104,10 +1108,6 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 * @return bool Returns true if succeed.
 	 */
 	public static function update_order_from_authorize_response( $order, $response, $capture_now = false ) {
-		if ( ! ( $order instanceof \WC_Order ) ) {
-			return false;
-		}
-
 		$auth_id = self::get_auth_id_from_response( $response );
 		if ( ! $auth_id ) {
 			return false;

--- a/includes/legacy/class-wc-amazon-payments-advanced-ipn-handler-legacy.php
+++ b/includes/legacy/class-wc-amazon-payments-advanced-ipn-handler-legacy.php
@@ -264,7 +264,9 @@ class WC_Amazon_Payments_Advanced_IPN_Handler_Legacy extends WC_Amazon_Payments_
 					'order_id' => $order_id,
 				)
 			);
-			add_post_meta( $order_id, 'amazon_refund_id', $refund_id );
+
+			$order->update_meta_data( 'amazon_refund_id', $refund_id );
+			$order->save();
 		}
 
 		// Buyer canceled the order.

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-legacy.php
@@ -445,6 +445,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 
 		$order->update_meta_data( 'amazon_timed_out_transaction', true );
 		$order->save();
+
 		$order->update_status( 'on-hold', __( 'Transaction with Amazon Pay is currently being validated.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 
 		// https://pay.amazon.com/it/developer/documentation/lpwa/201953810

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "scripts": {
     "test:php": "./vendor/bin/phpunit",
-    "lint:php": "./vendor/bin/phpcs",
+    "lint:php": "composer phpcs",
+    "fix:php": "composer phpcbf",
     "test": "cross-env NODE_CONFIG_DIR='./tests/e2e/config' BABEL_ENV=commonjs mocha \"tests/e2e\" --compilers js:babel-register --recursive",
     "test:grep": "cross-env NODE_CONFIG_DIR='./tests/e2e/config' BABEL_ENV=commonjs mocha \"tests/e2e\" --compilers js:babel-register --grep ",
     "test:single": "cross-env NODE_CONFIG_DIR='./tests/e2e/config' BABEL_ENV=commonjs mocha --compilers js:babel-register",

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -22,6 +22,16 @@
 define( 'WC_AMAZON_PAY_VERSION', '2.3.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_AMAZON_PAY_VERSION_CV1', '1.13.1' );
 
+// Declare HPOS compatibility.
+add_action(
+	'before_woocommerce_init',
+	function() {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		}
+	}
+);
+
 /**
  * Amazon Pay main class
  */

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -165,6 +165,9 @@ class WC_Amazon_Payments_Advanced {
 		include_once $this->includes_path . 'legacy/class-wc-amazon-payments-advanced-api-legacy.php';
 		include_once $this->includes_path . 'class-wc-amazon-payments-advanced-api.php';
 
+		// Utils.
+		include_once $this->includes_path . 'class-wc-amazon-payments-advanced-utils.php';
+
 		include_once $this->includes_path . 'class-wc-amazon-payments-advanced-compat.php';
 		include_once $this->includes_path . 'class-wc-amazon-payments-advanced-ipn-handler-abstract.php';
 		include_once $this->includes_path . 'class-wc-amazon-payments-advanced-ipn-handler.php';

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -518,20 +518,20 @@ class WC_Amazon_Payments_Advanced {
 			return $response;
 		}
 
-		$or = wc_get_order( $post->ID );
+		$order = wc_get_order( $post->ID );
 
-		if ( ! ( $or instanceof \WC_Order ) ) {
+		if ( ! ( $order instanceof \WC_Order ) ) {
 			return $response;
 		}
 
 		$response->data['amazon_reference'] = array(
 			'amazon_reference_state'     => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $post->ID, 'amazon_reference_state' ),
-			'amazon_reference_id'        => $or->get_meta( 'amazon_reference_id', true, 'edit' ),
+			'amazon_reference_id'        => $order->get_meta( 'amazon_reference_id', true, 'edit' ),
 			'amazon_authorization_state' => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $post->ID, 'amazon_authorization_state' ),
-			'amazon_authorization_id'    => $or->get_meta( 'amazon_authorization_id', true, 'edit' ),
+			'amazon_authorization_id'    => $order->get_meta( 'amazon_authorization_id', true, 'edit' ),
 			'amazon_capture_state'       => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $post->ID, 'amazon_capture_state' ),
-			'amazon_capture_id'          => $or->get_meta( 'amazon_capture_id', true, 'edit' ),
-			'amazon_refund_ids'          => $or->get_meta( 'amazon_refund_id', false, 'edit' ),
+			'amazon_capture_id'          => $order->get_meta( 'amazon_capture_id', true, 'edit' ),
+			'amazon_refund_ids'          => $order->get_meta( 'amazon_refund_id', false, 'edit' ),
 		);
 
 		return $response;

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -504,18 +504,25 @@ class WC_Amazon_Payments_Advanced {
 	 * @return WP_REST_Response REST response
 	 */
 	public function rest_api_add_amazon_ref_info( $response, $post ) {
-		if ( 'amazon_payments_advanced' === $response->data['payment_method'] ) {
-			$response->data['amazon_reference'] = array(
-
-				'amazon_reference_state'     => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $post->ID, 'amazon_reference_state' ),
-				'amazon_reference_id'        => get_post_meta( $post->ID, 'amazon_reference_id', true ),
-				'amazon_authorization_state' => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $post->ID, 'amazon_authorization_state' ),
-				'amazon_authorization_id'    => get_post_meta( $post->ID, 'amazon_authorization_id', true ),
-				'amazon_capture_state'       => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $post->ID, 'amazon_capture_state' ),
-				'amazon_capture_id'          => get_post_meta( $post->ID, 'amazon_capture_id', true ),
-				'amazon_refund_ids'          => get_post_meta( $post->ID, 'amazon_refund_id', false ),
-			);
+		if ( 'amazon_payments_advanced' !== $response->data['payment_method'] ) {
+			return $response;
 		}
+
+		$or = wc_get_order( $post->ID );
+
+		if ( ! ( $or instanceof \WC_Order ) ) {
+			return $response;
+		}
+
+		$response->data['amazon_reference'] = array(
+			'amazon_reference_state'     => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $post->ID, 'amazon_reference_state' ),
+			'amazon_reference_id'        => $or->get_meta( 'amazon_reference_id', true, 'edit' ),
+			'amazon_authorization_state' => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $post->ID, 'amazon_authorization_state' ),
+			'amazon_authorization_id'    => $or->get_meta( 'amazon_authorization_id', true, 'edit' ),
+			'amazon_capture_state'       => WC_Amazon_Payments_Advanced_API_Legacy::get_order_ref_state( $post->ID, 'amazon_capture_state' ),
+			'amazon_capture_id'          => $or->get_meta( 'amazon_capture_id', true, 'edit' ),
+			'amazon_refund_ids'          => $or->get_meta( 'amazon_refund_id', false, 'edit' ),
+		);
 
 		return $response;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Making Amazon Pay plugin compatible with HPOS

Made the plugin compatible using this [guide](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#declaring-extension-incompatibility)

Skipped:
- includes/compats/class-wc-amazon-payments-advanced-multi-currency-abstract.php L215-216

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes woo#226 .

### How to test the changes in this Pull Request:

1. [Enable](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#how-to-enable-hpos) HPOS in your installation.
2. Plugins functionality should remain the same regardless of HPOS unless you are using legacy API Keys

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ADD - Compatibility with HPOS