### PR TITLE
fix alexa's request format

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-alexa-notifications.php
+++ b/includes/class-wc-amazon-payments-advanced-alexa-notifications.php
@@ -72,8 +72,10 @@ class WC_Amazon_Payments_Advanced_Alexa_Notifications {
 			array(
 				'chargePermissionId' => $charge_permission_id,
 				'deliveryDetails'    => array(
-					'trackingNumber' => $tracking_number,
-					'carrierCode'    => $carrier,
+					array(
+						'trackingNumber' => $tracking_number,
+						'carrierCode'    => $carrier,
+					),
 				),
 			),
 			$order,


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. In sandobx mode you can in your code the below:
`do_action( 'woocommerce_amazon_pa_enable_alexa_notifications', 'ANYTHING_AS_TRACKING_NUMBER', 'VALID_AMAZON_CARRIER_CODE', (int) VALID_ORDER_ID_PAYED_WITH_AMAZON );`

You can find a list of valid amazon carrier codes [here](https://developer.amazon.com/docs/amazon-pay-checkout/setting-up-delivery-notifications.html)
2. You should see an entry in the amazon log under woocommerce > status > logs about the result of the delivery notification
3. The alexa delivery notification request should return a 200 status response to be succesful

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> FIX - Alexa delivery notification request format
