### PR TITLE
Fix order validation of rest routes

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
+++ b/includes/class-wc-amazon-payments-advanced-rest-api-controller.php
@@ -632,7 +632,7 @@ class WC_Amazon_Payments_Advanced_REST_API_Controller extends WC_REST_Controller
 			return new WP_Error( 'woocommerce_rest_order_invalid_id', __( 'Invalid order ID.', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 404 ) );
 		}
 
-		$is_valid = 'amazon_payments_advanced' === $order->get_payment_method()->id;
+		$is_valid = 'amazon_payments_advanced' === $order->get_payment_method();
 
 		return $is_valid ? $order : new WP_Error( 'woocommerce_rest_order_invalid_id', __( 'Invalid order ID.', 'woocommerce-gateway-amazon-payments-advanced' ), array( 'status' => 404 ) );
 	}

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2115,11 +2115,9 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 */
 	private function format_status_details( $status_details ) {
 		$charge_status         = $status_details->state; // phpcs:ignore WordPress.NamingConventions
-		$charge_status_reasons = $status_details->reasons; // phpcs:ignore WordPress.NamingConventions
-		if ( empty( $charge_status_reasons ) ) {
-			$charge_status_reasons = array();
-		}
-		$charge_status_reason = $status_details->reasonCode; // phpcs:ignore WordPress.NamingConventions
+		$charge_status_reasons = isset( $status_details->reasons ) && is_array( $status_details->reasons ) ? $status_details->reasons : array(); // phpcs:ignore WordPress.NamingConventions
+
+		$charge_status_reason = isset( $status_details->reasonCode ) ? $status_details->reasonCode : null; // phpcs:ignore WordPress.NamingConventions
 
 		if ( $charge_status_reason ) {
 			$charge_status_reasons[] = (object) array(


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Rest routes registered in includes/class-wc-amazon-payments-advanced-rest-api-controller.php by WC_Amazon_Payments_Advanced_REST_API_Controller::register_routes should function as expected and correctly identifing if the provided order id refers to an actual order completed through Amazon Pay

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Order Validation on Rest Routes
