### PR TITLE
Fix the button on single product page to appear only when applicable

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -626,13 +626,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 * @return void
 	 */
 	public function maybe_separator_and_checkout_button_single_product() {
-		$product = wc_get_product();
-
-		if ( ! $product instanceof \WC_Product ) {
-			return;
-		}
-
-		if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
+		if ( ! $this->is_product_purchasable_and_in_stock() ) {
 			return;
 		}
 
@@ -2842,17 +2836,27 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			return $load_scripts;
 		}
 
-		$product = wc_get_product();
-
-		if ( ! $product instanceof \WC_Product ) {
-			return $load_scripts;
-		}
-
-		if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
+		if ( ! $this->is_product_purchasable_and_in_stock() ) {
 			return $load_scripts;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks if a product is purchasable and in stock.
+	 *
+	 * @param bool|int|WC_Product $the_product Instance of product to check or product id or false to use the current product.
+	 * @return bool True if product is purchasable and in stock, false otherwise.
+	 */
+	protected function is_product_purchasable_and_in_stock( $the_product = false ) {
+		$product = wc_get_product( $the_product );
+
+		if ( ! $product instanceof \WC_Product ) {
+			return false;
+		}
+
+		return $product->is_purchasable() && $product->is_in_stock();
 	}
 
 	/**

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -626,13 +626,13 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 * @return void
 	 */
 	public function maybe_separator_and_checkout_button_single_product() {
-		$prd = wc_get_product();
+		$product = wc_get_product();
 
-		if ( ! $prd instanceof \WC_Product ) {
+		if ( ! $product instanceof \WC_Product ) {
 			return;
 		}
 
-		if ( ! $prd->is_purchasable() || ! $prd->is_in_stock() ) {
+		if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
 			return;
 		}
 
@@ -2842,13 +2842,13 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			return $load_scripts;
 		}
 
-		$prd = wc_get_product();
+		$product = wc_get_product();
 
-		if ( ! $prd instanceof \WC_Product ) {
+		if ( ! $product instanceof \WC_Product ) {
 			return $load_scripts;
 		}
 
-		if ( ! $prd->is_purchasable() || ! $prd->is_in_stock() ) {
+		if ( ! $product->is_purchasable() || ! $product->is_in_stock() ) {
 			return $load_scripts;
 		}
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -619,11 +619,23 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	/**
 	 * Prints the Amazon Pay button on the product page when the setting is on.
 	 *
+	 * Additionally checks that the product is purchasable and not out of stock.
+	 *
 	 * @hooked on 'woocommerce_single_product_summary' on 35 priority
 	 *
 	 * @return void
 	 */
 	public function maybe_separator_and_checkout_button_single_product() {
+		$prd = wc_get_product();
+
+		if ( ! $prd instanceof \WC_Product ) {
+			return;
+		}
+
+		if ( ! $prd->is_purchasable() || ! $prd->is_in_stock() ) {
+			return;
+		}
+
 		if ( $this->is_available() && $this->possible_subscription_product_supported() && $this->is_product_button_enabled() ) {
 			$this->checkout_button( true, 'div', 'pay_with_amazon_product' );
 		}
@@ -2815,13 +2827,32 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	}
 
 	/**
-	 * Loads scripts on product pages when the setting to display Amazon Pay button on products is enabled.
+	 * Loads scripts on product pages when the setting to display Amazon Pay button on products is enabled
+	 * and the product is purchasable and not out of stock.
 	 *
 	 * @param bool $load_scripts Whether to load Amazon Pay scripts or not.
 	 * @return bool
 	 */
 	public function load_scripts_on_product_pages( $load_scripts ) {
-		return $load_scripts ? $load_scripts : is_product() && $this->is_product_button_enabled();
+		if ( ! is_product() ) {
+			return $load_scripts;
+		}
+
+		if ( ! $this->is_product_button_enabled() ) {
+			return $load_scripts;
+		}
+
+		$prd = wc_get_product();
+
+		if ( ! $prd instanceof \WC_Product ) {
+			return $load_scripts;
+		}
+
+		if ( ! $prd->is_purchasable() || ! $prd->is_in_stock() ) {
+			return $load_scripts;
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/phpunit/includes/test-wc-gateway-amazon-payments-advanced.php
+++ b/tests/phpunit/includes/test-wc-gateway-amazon-payments-advanced.php
@@ -63,20 +63,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Test extends WP_UnitTestCase {
 	 */
 	public function test_is_available() : void {
 		// Update plugin settings to make the gateway available.
-		$settings = WC_Amazon_Payments_Advanced_API::get_settings();
-		$settings = array_merge(
-			$settings,
-			array(
-				'enabled'        => 'yes',
-				'merchant_id'    => 'test_merchant_id',
-				'public_key_id'  => 'test_public_key_id',
-				'store_id'       => 'test_store_id',
-				'payment_region' => 'eu',
-			)
-		);
-
-		update_option( 'woocommerce_amazon_payments_advanced_settings', $settings );
-		update_option( WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::KEYS_OPTION_PRIVATE_KEY, 'TEST_PRIVATE_KEY' );
+		$this->make_gateway_available();
 
 		// Test gateway availability.
 		$this->assertTrue( self::$gateway->is_available() );
@@ -135,5 +122,119 @@ class WC_Gateway_Amazon_Payments_Advanced_Test extends WP_UnitTestCase {
 			),
 			$mock_gateway->process_payment( $order->get_id() )
 		);
+	}
+
+	/**
+	 * Test maybe_separator_and_checkout_button_single_product method.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_separator_and_checkout_button_single_product() : void {
+		ob_start();
+		self::$gateway->maybe_separator_and_checkout_button_single_product();
+		$should_fail_because_no_global_product = ob_get_clean();
+
+		$this->assertEmpty( $should_fail_because_no_global_product );
+
+		$test_product = WC_Helper_Product::create_and_optionally_save_simple_product( true );
+
+		$test_product->set_stock_status( 'outofstock' );
+
+		$test_product->save();
+
+		$GLOBALS['post'] = get_post( $test_product->get_id() );
+
+		ob_start();
+		self::$gateway->maybe_separator_and_checkout_button_single_product();
+		$should_fail_because_out_of_stock = ob_get_clean();
+
+		$this->assertEmpty( $should_fail_because_out_of_stock );
+
+		$test_product->set_stock_status( 'instock' );
+
+		$test_product->save();
+
+		$GLOBALS['post'] = get_post( $test_product->get_id() );
+
+		ob_start();
+		self::$gateway->maybe_separator_and_checkout_button_single_product();
+		$should_fail_because_plugin_option_is_not_enabled = ob_get_clean();
+
+		$this->assertEmpty( $should_fail_because_plugin_option_is_not_enabled );
+
+		// Enable gateway and update single button settings.
+		$this->make_gateway_available( array( 'product_button' => 'yes' ) );
+		self::$gateway->init_settings();
+
+		$expected_for_success = self::$gateway->checkout_button( false, 'div', 'pay_with_amazon_product' );
+
+		ob_start();
+		self::$gateway->maybe_separator_and_checkout_button_single_product();
+		$actual_markup = ob_get_clean();
+
+		$this->assertEquals( $expected_for_success, $actual_markup );
+	}
+
+	/**
+	 * Test load_scripts_on_product_pages method.
+	 *
+	 * @return void
+	 */
+	public function test_load_scripts_on_product_pages() {
+		// If given true it should always return true, no matter what.
+		$this->assertTrue( self::$gateway->load_scripts_on_product_pages( true ) );
+
+		// Should return false, since this is not a product page.
+		$this->assertFalse( self::$gateway->load_scripts_on_product_pages( false ) );
+
+		$test_product = WC_Helper_Product::create_and_optionally_save_simple_product( true );
+
+		$test_product->set_stock_status( 'outofstock' );
+
+		$test_product->save();
+
+		// Force the global post to the newly created test product.
+		$GLOBALS['post'] = get_post( $test_product->get_id() );
+
+		// Force the global query to be a singular product query.
+		$GLOBALS['wp_query']->is_singular    = true;
+		$GLOBALS['wp_query']->queried_object = $GLOBALS['post'];
+
+		// Scripts should not be loaded since product is out of stock.
+		$this->assertFalse( self::$gateway->load_scripts_on_product_pages( false ) );
+
+		$test_product->set_stock_status( 'instock' );
+
+		$test_product->save();
+
+		// Force the global post to the newly created test product.
+		$GLOBALS['post'] = get_post( $test_product->get_id() );
+
+		// Scripts should be loaded since product is in stock.
+		$this->assertTrue( self::$gateway->load_scripts_on_product_pages( false ) );
+	}
+
+	/**
+	 * Helper method to make the Gateway available.
+	 *
+	 * @param array $extras Extra settings to update the gateway with.
+	 * @return void
+	 */
+	protected function make_gateway_available( array $extras = array() ) {
+		$settings = WC_Amazon_Payments_Advanced_API::get_settings();
+		$settings = array_merge(
+			$settings,
+			array(
+				'enabled'        => 'yes',
+				'merchant_id'    => 'test_merchant_id',
+				'public_key_id'  => 'test_public_key_id',
+				'store_id'       => 'test_store_id',
+				'payment_region' => 'eu',
+			),
+			$extras
+		);
+
+		update_option( 'woocommerce_amazon_payments_advanced_settings', $settings );
+		update_option( WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::KEYS_OPTION_PRIVATE_KEY, 'TEST_PRIVATE_KEY' );
 	}
 }

--- a/tests/phpunit/includes/test-wc-gateway-amazon-payments-advanced.php
+++ b/tests/phpunit/includes/test-wc-gateway-amazon-payments-advanced.php
@@ -137,9 +137,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Test extends WP_UnitTestCase {
 		$this->assertEmpty( $should_fail_because_no_global_product );
 
 		$test_product = WC_Helper_Product::create_and_optionally_save_simple_product( true );
-
 		$test_product->set_stock_status( 'outofstock' );
-
 		$test_product->save();
 
 		$GLOBALS['post'] = get_post( $test_product->get_id() );
@@ -149,9 +147,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Test extends WP_UnitTestCase {
 		$should_fail_because_out_of_stock = ob_get_clean();
 
 		$this->assertEmpty( $should_fail_because_out_of_stock );
-
 		$test_product->set_stock_status( 'instock' );
-
 		$test_product->save();
 
 		$GLOBALS['post'] = get_post( $test_product->get_id() );
@@ -188,9 +184,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Test extends WP_UnitTestCase {
 		$this->assertFalse( self::$gateway->load_scripts_on_product_pages( false ) );
 
 		$test_product = WC_Helper_Product::create_and_optionally_save_simple_product( true );
-
 		$test_product->set_stock_status( 'outofstock' );
-
 		$test_product->save();
 
 		// Force the global post to the newly created test product.
@@ -202,9 +196,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Test extends WP_UnitTestCase {
 
 		// Scripts should not be loaded since product is out of stock.
 		$this->assertFalse( self::$gateway->load_scripts_on_product_pages( false ) );
-
 		$test_product->set_stock_status( 'instock' );
-
 		$test_product->save();
 
 		// Force the global post to the newly created test product.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes woo#251 .

### How to test the changes in this Pull Request:

1. Enable the Amazon Pay for single product pages from the plugin's options
2. Set a product to in stock or backorder. The Amazon pay button should appear.
3. Set the product as out of stock. The product should dissappear and Amazon pay related scripts should not be loaded in the page.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Amazon pay button should appear on single product page only when the product is purchasable and in stock.
