### PR TITLE
Fix/issue 270 estimated order amount multicurrency

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -213,12 +213,16 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 	 * @since 1.8.0
 	 * @version 1.8.0
 	 *
+	 * @param string $currency Currency code.
+	 *
 	 * @return bool Returns true if shop currency is supported by current payment region.
 	 */
-	public static function is_region_supports_shop_currency() {
+	public static function is_region_supports_shop_currency( $currency = false ) {
 		$region = self::get_region();
 		// Take into consideration external multi-currency plugins when not supported multicurrency region.
-		$currency = apply_filters( 'woocommerce_amazon_pa_active_currency', get_option( 'woocommerce_currency' ) );
+		if ( ! $currency ) {
+			$currency = apply_filters( 'woocommerce_amazon_pa_active_currency', get_option( 'woocommerce_currency' ) );
+		}
 
 		switch ( $region ) {
 			case 'eu':

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -3030,10 +3030,16 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			return '';
 		}
 
+		$active_currency = WC_Amazon_Payments_Advanced_Multi_Currency::is_active() ? WC_Amazon_Payments_Advanced_Multi_Currency::get_selected_currency() : get_woocommerce_currency();
+
+		if ( ! WC_Amazon_Payments_Advanced_API::is_region_supports_shop_currency( $active_currency ) ) {
+			return '';
+		}
+
 		return wp_json_encode(
 			array(
 				'amount'       => WC()->cart->get_total( 'amount' ),
-				'currencyCode' => get_woocommerce_currency(),
+				'currencyCode' => $active_currency,
 			)
 		);
 	}

--- a/tests/phpunit/includes/test-wc-gateway-amazon-payments-advanced.php
+++ b/tests/phpunit/includes/test-wc-gateway-amazon-payments-advanced.php
@@ -113,14 +113,44 @@ class WC_Gateway_Amazon_Payments_Advanced_Test extends WP_UnitTestCase {
 				'result'                     => 'success',
 				'redirect'                   => '#amazon-pay-classic-id-that-should-not-exist',
 				'amazonCreateCheckoutParams' => wp_json_encode( WC_Mocker_Amazon_Payments_Advanced_API::get_create_checkout_classic_session_config( array( 'test' ) ) ),
-				'amazonEstimatedOrderAmount' => wp_json_encode(
-					array(
-						'amount'       => $order_total,
-						'currencyCode' => get_woocommerce_currency(),
-					)
-				),
+				'amazonEstimatedOrderAmount' => $mock_gateway::get_estimated_order_amount(),
 			),
 			$mock_gateway->process_payment( $order->get_id() )
+		);
+	}
+
+	/**
+	 * Test estimated order amount with multi-currency.
+	 *
+	 * @return void
+	 */
+	public function test_estimated_order_amount_output() : void {
+		$checkout_session_key = apply_filters( 'woocommerce_amazon_pa_checkout_session_key', 'amazon_checkout_session_id' );
+		WC()->session->set( $checkout_session_key, null );
+		WC()->session->save_data();
+
+		$order_total = 100;
+
+		update_option( 'woocommerce_default_country', 'ES:B' );
+		update_option( 'woocommerce_currency', 'EUR' );
+
+		$eu_mock_gateway = new WC_Mocker_Gateway_Amazon_Payments_Advanced( $order_total );
+
+		$this->assertEquals(
+			wp_json_encode(
+				array(
+					'amount'       => $order_total,
+					'currencyCode' => 'EUR',
+				)
+			),
+			$eu_mock_gateway::get_estimated_order_amount(),
+		);
+
+		update_option( 'woocommerce_currency', 'USD' );
+
+		$this->assertEquals(
+			'',
+			$eu_mock_gateway::get_estimated_order_amount()
 		);
 	}
 

--- a/tests/phpunit/mockers/class-wc-mocker-amazon-payments-advanced-api.php
+++ b/tests/phpunit/mockers/class-wc-mocker-amazon-payments-advanced-api.php
@@ -51,4 +51,24 @@ class WC_Mocker_Amazon_Payments_Advanced_API {
 			'signature'   => $signature,
 		);
 	}
+
+	public static function is_region_supports_shop_currency( $region, $currency = false ) : bool {
+
+		if ( ! $currency ) {
+			$currency = get_woocommerce_currency();
+		}
+		
+		switch ( $region ) {
+			case 'eu':
+				return 'EUR' === $currency;
+			case 'gb':
+				return 'GBP' === $currency;
+			case 'us':
+				return 'USD' === $currency;
+			case 'jp':
+				return 'JPY' === $currency;
+		}
+
+		return false;
+	}
 }

--- a/tests/phpunit/mockers/class-wc-mocker-gateway-amazon-payments-advanced.php
+++ b/tests/phpunit/mockers/class-wc-mocker-gateway-amazon-payments-advanced.php
@@ -77,11 +77,21 @@ class WC_Mocker_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payme
 	 *
 	 * @return string
 	 */
-	protected static function get_estimated_order_amount() : string {
+	public static function get_estimated_order_amount() : string {
+		if ( null === WC()->cart ) {
+			return '';
+		}
+
+		$active_currency = get_woocommerce_currency();
+
+		if ( ! WC_Mocker_Amazon_Payments_Advanced_API::is_region_supports_shop_currency( WC_Amazon_Payments_Advanced_API::get_settings('payment_region'), $active_currency ) ) {
+			return '';
+		}
+
 		return wp_json_encode(
 			array(
 				'amount'       => self::$order_total,
-				'currencyCode' => get_woocommerce_currency(),
+				'currencyCode' => $active_currency,
 			)
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Disable the estimated order amount if the currency is not the default currency for the region.

Closes #270.

### How to test the changes in this Pull Request:

1. Install a built version of this branch and setup the amazon plugin to Europe region.
2. Install the plugin `FOX - Currency Switcher Professional for WooCommerce`.
3. Estimated order amount should be set when the currency is EUR but should not be set when the currency is USD.
4. The checkout can be completed without issues.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Fix - Issue with estimated order amount and multi-currency.
