### PR TITLE
do not display the separator on minicart if button should be hidden

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -1148,4 +1148,16 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	protected function using_woo_blocks() {
 		return ! empty( $this->settings['using_woo_blocks'] ) && 'yes' === $this->settings['using_woo_blocks'];
 	}
+
+	/**
+	 * Return if the hide button mode is enabled.
+	 *
+	 * @return boolean
+	 */
+	protected function is_hide_button_mode_enabled() {
+		$hide_button_mode_enabled = 'yes' === $this->settings['hide_button_mode'];
+		$hide_button_mode_enabled = apply_filters( 'woocommerce_amazon_payments_hide_amazon_buttons', $hide_button_mode_enabled );
+
+		return $hide_button_mode_enabled;
+	}
 }

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -608,7 +608,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 * @return void
 	 */
 	public function maybe_separator_and_checkout_button() {
-		if ( $this->is_available() && $this->possible_subscription_cart_supported() && $this->is_mini_cart_button_enabled() && WC()->cart->get_cart_contents_count() > 0 ) {
+		if ( $this->is_available() && $this->possible_subscription_cart_supported() && $this->is_mini_cart_button_enabled() && ! $this->is_hide_button_mode_enabled() && WC()->cart->get_cart_contents_count() > 0 ) {
 			?>
 			<div class="woocommerce-mini-cart__buttons buttons">
 				<?php
@@ -2420,10 +2420,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 * @since 1.6.0
 	 */
 	public function maybe_hide_amazon_buttons() {
-		$hide_button_mode_enabled = 'yes' === $this->settings['hide_button_mode'];
-		$hide_button_mode_enabled = apply_filters( 'woocommerce_amazon_payments_hide_amazon_buttons', $hide_button_mode_enabled );
-
-		if ( ! $hide_button_mode_enabled ) {
+		if ( ! $this->is_hide_button_mode_enabled() ) {
 			return;
 		}
 

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-legacy.php
@@ -1623,10 +1623,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 	 * @since 1.6.0
 	 */
 	public function maybe_hide_amazon_buttons() {
-		$hide_button_mode_enabled = ( 'yes' === $this->settings['enabled'] && 'yes' === $this->settings['hide_button_mode'] );
-		$hide_button_mode_enabled = apply_filters( 'woocommerce_amazon_payments_hide_amazon_buttons', $hide_button_mode_enabled );
-
-		if ( ! $hide_button_mode_enabled ) {
+		if ( ! $this->is_hide_button_mode_enabled() ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

### How to test the changes in this Pull Request:

1. Install a build version of this branch.
2. Enable the button on the mini-cart and the option Hide Button Mode.
3. The -- OR -- separator shouldn't be visible in the minicart.


### Changelog entry

> Fix - Button separator displayed on the mini-cart when it shouldn't.
