### PR TITLE
Fix/add compatibility product add on gravity add on

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2894,16 +2894,18 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 */
 	public function ajax_amazon_change_wc_carts() {
 		check_ajax_referer( 'amazon_change_wc_carts', '_change_carts_nonce' );
-		if ( ! empty( $_GET['product_id'] ) && ! empty( $_GET['quantity'] ) ) {
-			$selected_product = absint( $_GET['product_id'] );
-			$quantity         = absint( $_GET['quantity'] );
-			$variation_id     = ! empty( $_GET['variation_id'] ) ? absint( $_GET['variation_id'] ) : 0;
+		if ( ! empty( $_POST['product_id'] ) && ! empty( $_POST['quantity'] ) ) {
+			$selected_product_id = absint( $_POST['product_id'] );
+			$quantity            = absint( $_POST['quantity'] );
+
+			$variation_id = ! empty( $_POST['variation_id'] ) ? absint( $_POST['variation_id'] ) : 0;
 			if ( $variation_id ) {
 				$variation = new WC_Product_Variation( $variation_id );
 				$attrs     = $variation->get_variation_attributes();
 			} else {
 				$attrs = array();
 			}
+
 			if ( WC()->cart->get_cart_contents_count() > 0 ) {
 				WC()->session->set( 'amazon_pay_cart', WC()->cart->get_cart_for_session() );
 				foreach ( self::$session_keys as $session_key ) {
@@ -2915,7 +2917,8 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				WC()->session->save_data();
 				WC()->cart->empty_cart();
 			}
-			WC()->cart->add_to_cart( $selected_product, $quantity, $variation_id, $attrs );
+
+			WC()->cart->add_to_cart( $selected_product_id, $quantity, $variation_id, $attrs );
 			$checkout_session_config = WC_Amazon_Payments_Advanced_API::get_create_checkout_session_config();
 
 			$data = array(

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2898,6 +2898,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			$selected_product_id = absint( $_POST['product_id'] );
 			$quantity            = absint( $_POST['quantity'] );
 
+			$passed_validation = apply_filters( 'woocommerce_add_to_cart_validation', true, $selected_product_id, $quantity );
+			if ( ! $passed_validation ) {
+				wp_send_json_error();
+			}
+
 			$variation_id = ! empty( $_POST['variation_id'] ) ? absint( $_POST['variation_id'] ) : 0;
 			if ( $variation_id ) {
 				$variation = new WC_Product_Variation( $variation_id );

--- a/src/js/non-block/amazon-wc-checkout.js
+++ b/src/js/non-block/amazon-wc-checkout.js
@@ -125,7 +125,7 @@
 					$.ajax(
 						{
 							url: amazon_payments_advanced.ajax_url,
-							type: 'get',
+							type: 'post',
 							data: $.param( data ),
 							success: function( result ) {
 								if ( result.data.create_checkout_session_config ) {

--- a/src/js/non-block/amazon-wc-checkout.js
+++ b/src/js/non-block/amazon-wc-checkout.js
@@ -113,6 +113,11 @@
 					$.each( singleAddToCart.closest( 'form.cart' ).serializeArray(), function( index, object ) {
 						if ( 'add-to-cart' === object.name ) {
 							data.product_id = object.value;
+						} else if ( 'undefined' !== typeof data[ object.name ] ) {
+							if ( ! $.isArray( data[ object.name ] ) ) {
+								data[ object.name ] = [ data[ object.name ] ];
+							}
+							data[ object.name ].push( object.value );
 						} else {
 							data[ object.name ] = object.value;
 						}

--- a/src/js/non-block/amazon-wc-checkout.js
+++ b/src/js/non-block/amazon-wc-checkout.js
@@ -111,7 +111,7 @@
 					};
 
 					$.each( singleAddToCart.closest( 'form.cart' ).serializeArray(), function( index, object ) {
-						if ( 'add-to-cart' === object.name ) {
+						if ( [ 'add-to-cart', 'product_id' ].includes( object.name ) ) {
 							data.product_id = object.value;
 						} else if ( 'undefined' !== typeof data[ object.name ] ) {
 							if ( ! $.isArray( data[ object.name ] ) ) {

--- a/src/js/non-block/amazon-wc-checkout.js
+++ b/src/js/non-block/amazon-wc-checkout.js
@@ -156,7 +156,7 @@
 							type: 'post',
 							data: $.param( data ),
 							success: function( result ) {
-								if ( result.data.create_checkout_session_config ) {
+								if ( 'undefined' !== typeof result.data && result.data.create_checkout_session_config ) {
 									if ( result.data.estimated_order_amount ) {
 										var productsEstimatedOrderAmount = JSON.parse( result.data.estimated_order_amount );
 										if ( 'undefined' !== typeof productsEstimatedOrderAmount.amount && 'undefined' !== typeof productsEstimatedOrderAmount.currencyCode ) {

--- a/src/js/non-block/amazon-wc-checkout.js
+++ b/src/js/non-block/amazon-wc-checkout.js
@@ -87,7 +87,30 @@
 		var amazonProductButtonContainer = $( '#pay_with_amazon_product' );
 
 		if ( amazonProductButtonContainer.length > 0 ) {
+			renderProductButton();
 
+			$( document.body ).on( 'woocommerce_variation_has_changed', function() {
+				$( '#pay_with_amazon_product' ).each( function() {
+					$( this ).data( 'amazonRenderedSettings', null );
+				} );
+				renderProductButton();
+			} );
+		}
+
+		function submit_error( $element, errorMessage ) {
+			$( '.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message' ).remove();
+			$element.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + errorMessage + '</div>' ); // eslint-disable-line max-len
+			$element.removeClass( 'processing' ).unblock();
+		}
+
+		function renderAndInitAmazonCheckout( buttonId, flag, checkoutConfig ) {
+			var amazonClassicButton = renderButton( buttonId, flag );
+			if ( null !== amazonClassicButton ) {
+				amazonClassicButton.initCheckout( { createCheckoutSessionConfig: checkoutConfig } );
+			}
+		}
+
+		function renderProductButton() {
 			var amazonProductButton = renderButton( '#pay_with_amazon_product', 'product' );
 
 			if ( null !== amazonProductButton ) {
@@ -155,19 +178,6 @@
 						}
 					} );
 				} );
-			}
-		}
-
-		function submit_error( $element, errorMessage ) {
-			$( '.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message' ).remove();
-			$element.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + errorMessage + '</div>' ); // eslint-disable-line max-len
-			$element.removeClass( 'processing' ).unblock();
-		}
-
-		function renderAndInitAmazonCheckout( buttonId, flag, checkoutConfig ) {
-			var amazonClassicButton = renderButton( buttonId, flag );
-			if ( null !== amazonClassicButton ) {
-				amazonClassicButton.initCheckout( { createCheckoutSessionConfig: checkoutConfig } );
 			}
 		}
 
@@ -262,6 +272,27 @@
 			return ! $( '.wc-apa-widget-change' ).length && ( 'amazon_payments_advanced' === $( 'input[name=payment_method]:checked' ).val() );
 		}
 
+		function getCurrentProductType() {
+
+			var productType = amazon_payments_advanced.product_action;
+
+			const variations_form = $( 'form.variations_form' );
+
+			if ( variations_form.length > 0 ) {
+				const current_variation = parseInt( variations_form.find( 'input[name="variation_id"]' ).val() );
+
+				if ( current_variation ) {
+					$.each( variations_form.data('product_variations'), function( index, variation ) {
+						if ( current_variation === parseInt( variation.variation_id ) && 'undefined' !== typeof variation.wc_amazon_product_type ) {
+							productType = variation.wc_amazon_product_type;
+						}
+					} );
+				}
+			}
+
+			return productType;
+		}
+
 		function getButtonSettings( buttonSettingsFlag ) {
 			var obj = {
 				// set checkout environment
@@ -275,7 +306,7 @@
 				productType: amazon_payments_advanced.action,
 			};
 			if ( 'product' === buttonSettingsFlag ) {
-				obj.productType = amazon_payments_advanced.product_action;
+				obj.productType = getCurrentProductType();
 			} else if ( 'classic' === buttonSettingsFlag && null !== amazonCreateCheckoutConfig ) {
 				obj.productType = 'undefined' !== typeof amazonCreateCheckoutConfig.payloadJSON.addressDetails ? 'PayAndShip' : 'PayOnly';
 				amazonCreateCheckoutConfig.payloadJSON = JSON.stringify( amazonCreateCheckoutConfig.payloadJSON );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Fix compatibility issues with Woo Product Add-On and Gravity Forms Add-On

### How to test the changes in this Pull Request:

1. Install a built version of this PR.
2. Install and setup Gravity Forms Add-On and Product Add-On.
3. The extra fees added by the Add-On should be added as well using the Express Checkout from the product page.

### Changelog entry

> Fix - Compatibility with Woo Product Add-On
> Fix - Compatibility with WooCommerce Gravity Forms Product Add-Ons
