### PR TITLE
Force decimals with JPY always to be 0

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -523,6 +523,25 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 	}
 
 	/**
+	 * Format the charge amount, make sure that decimals with JPY is 0.
+	 *
+	 * @param array $charge_amount The charge amount.
+	 */
+	public static function format_charge_amount( $charge_amount ) {
+
+		if ( empty( $charge_amount['currencyCode'] ) || empty( $charge_amount['amount'] ) ) {
+			return $charge_amount;
+		}
+
+		switch ( $charge_amount['currencyCode'] ) {
+			case 'JPY':
+				$charge_amount['amount'] = WC_Amazon_Payments_Advanced::format_amount( $charge_amount['amount'], 0 );
+		}
+
+		return $charge_amount;
+	}
+
+	/**
 	 * Validate API Keys signature
 	 *
 	 * @return bool

--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -435,6 +435,8 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		$payload['chargeAmount']['amount'] = WC_Amazon_Payments_Advanced::format_amount( $recurring_total );
 
+		$payload['chargeAmount'] = WC_Amazon_Payments_Advanced_API::format_charge_amount( $payload['chargeAmount'] );
+
 		return $payload;
 	}
 
@@ -545,16 +547,18 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		$currency = wc_apa_get_order_prop( $order, 'order_currency' );
 
+		$charge_amount = array(
+			'amount'       => WC_Amazon_Payments_Advanced::format_amount( $amount_to_charge ),
+			'currencyCode' => $currency,
+		);
+
 		$response = WC_Amazon_Payments_Advanced_API::create_charge(
 			$charge_permission_id,
 			array(
 				'merchantMetadata'              => WC_Amazon_Payments_Advanced_API::get_merchant_metadata( $order_id ),
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
-				'chargeAmount'                  => array(
-					'amount'       => WC_Amazon_Payments_Advanced::format_amount( $amount_to_charge ),
-					'currencyCode' => $currency,
-				),
+				'chargeAmount'                  => WC_Amazon_Payments_Advanced_API::format_charge_amount( $charge_amount ),
 			)
 		);
 

--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -303,11 +303,13 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			);
 
 			if ( 1 === $subscriptions_in_cart ) {
-				$first_recurring                        = reset( WC()->cart->recurring_carts );
-				$payload['recurringMetadata']['amount'] = array(
+				$first_recurring         = reset( WC()->cart->recurring_carts );
+				$recurring_charge_amount = array(
 					'amount'       => WC_Amazon_Payments_Advanced::format_amount( $first_recurring->get_total( 'edit' ) ),
 					'currencyCode' => get_woocommerce_currency(),
 				);
+
+				$payload['recurringMetadata']['amount'] = WC_Amazon_Payments_Advanced_API::format_charge_amount( $recurring_charge_amount );
 			}
 		} elseif ( $cart_contains_renewal || $change_payment_for_subscription ) {
 			if ( $cart_contains_renewal ) {
@@ -328,12 +330,14 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 			$payload['chargePermissionType'] = 'Recurring';
 
+			$recurring_charge_amount = array(
+				'amount'       => WC_Amazon_Payments_Advanced::format_amount( $subscription->get_total() ),
+				'currencyCode' => wc_apa_get_order_prop( $subscription, 'order_currency' ),
+			);
+
 			$payload['recurringMetadata'] = array(
 				'frequency' => $this->parse_interval_to_apa_frequency( $subscription->get_billing_period( 'edit' ), $subscription->get_billing_interval( 'edit' ) ),
-				'amount'    => array(
-					'amount'       => WC_Amazon_Payments_Advanced::format_amount( $subscription->get_total() ),
-					'currencyCode' => wc_apa_get_order_prop( $subscription, 'order_currency' ),
-				),
+				'amount'    => WC_Amazon_Payments_Advanced_API::format_charge_amount( $recurring_charge_amount ),
 			);
 		}
 
@@ -386,10 +390,12 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 		$recurring_total = wc_format_decimal( $recurring_total, '' );
 
 		if ( 1 === $subscriptions_in_cart ) {
-			$payload['recurringMetadata']['amount'] = array(
+			$recurring_charge_amount = array(
 				'amount'       => WC_Amazon_Payments_Advanced::format_amount( $recurring_total ),
 				'currencyCode' => wc_apa_get_order_prop( $order, 'order_currency' ),
 			);
+
+			$payload['recurringMetadata']['amount'] = WC_Amazon_Payments_Advanced_API::format_charge_amount( $recurring_charge_amount );
 		}
 
 		if ( 0 >= (float) WC()->cart->get_total( 'edit' ) ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1422,16 +1422,18 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				$can_do_async = true;
 			}
 
+			$charge_amount = array(
+				'amount'       => $order_total,
+				'currencyCode' => $currency,
+			);
+
 			$payload['paymentDetails'] = array_merge(
 				isset( $payload['paymentDetails'] ) && is_array( $payload['paymentDetails'] ) ? $payload['paymentDetails'] : array(),
 				array(
 					'paymentIntent'                 => $payment_intent,
 					'canHandlePendingAuthorization' => $can_do_async,
 					// "softDescriptor" => "Descriptor", // TODO: Implement setting, if empty, don't set this. ONLY FOR AuthorizeWithCapture
-					'chargeAmount'                  => array(
-						'amount'       => $order_total,
-						'currencyCode' => $currency,
-					),
+					'chargeAmount'                  => WC_Amazon_Payments_Advanced_API::format_charge_amount( $charge_amount ),
 				)
 			);
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1555,15 +1555,17 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$this->get_lock_for_order( $order_id, true );
 
+		$charge_amount = array(
+			'amount'       => $order_total,
+			'currencyCode' => $currency,
+		);
+
 		$response = WC_Amazon_Payments_Advanced_API::complete_checkout_session(
 			$checkout_session_id,
 			apply_filters(
 				'woocommerce_amazon_pa_update_complete_checkout_session_payload',
 				array(
-					'chargeAmount' => array(
-						'amount'       => $order_total,
-						'currencyCode' => $currency,
-					),
+					'chargeAmount' => WC_Amazon_Payments_Advanced_API::format_charge_amount( $charge_amount ),
 				),
 				$checkout_session_id,
 				$order
@@ -2467,16 +2469,18 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$currency = wc_apa_get_order_prop( $order, 'order_currency' );
 
+		$charge_amount = array(
+			'amount'       => WC_Amazon_Payments_Advanced::format_amount( $order->get_total() ),
+			'currencyCode' => $currency,
+		);
+
 		$charge = WC_Amazon_Payments_Advanced_API::create_charge(
 			$id,
 			array(
 				'merchantMetadata'              => WC_Amazon_Payments_Advanced_API::get_merchant_metadata( $order_id ),
 				'captureNow'                    => $capture_now,
 				'canHandlePendingAuthorization' => $can_do_async,
-				'chargeAmount'                  => array(
-					'amount'       => WC_Amazon_Payments_Advanced::format_amount( $order->get_total() ),
-					'currencyCode' => $currency,
-				),
+				'chargeAmount'                  => WC_Amazon_Payments_Advanced_API::format_charge_amount( $charge_amount ),
 			)
 		);
 

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -320,7 +320,7 @@ class WC_Amazon_Payments_Advanced {
 	public static function format_amount( $num, $decimals = null, $decimals_sep = '.', $thousands_sep = '' ) {
 		/* Amazon won't accept any decimals more than 2. */
 		$decimals = $decimals > 2 ? null : $decimals;
-		$decimals = $decimals ? $decimals : min( wc_get_price_decimals(), 2 );
+		$decimals = null !== $decimals ? $decimals : min( wc_get_price_decimals(), 2 );
 		return number_format( $num, $decimals, $decimals_sep, $thousands_sep );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Rel card: https://app.clickup.com/t/860qe8m2e

### How to test the changes in this Pull Request:

1. Install a built of this PR and the Price Based on Country plugin (free version)
2. Add Japan with JPY currency in the Price Based on Country plugin.
3. A customer with shipping address on Japan should be able to complete the checkout.

### Changelog entry

> Fix - Checkout error with JPY currency and decimals set to non 0.