### PR TITLE
Fix function to get privacy_url

### DIFF
--- a/includes/admin/class-wc-amazon-payments-advanced-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-admin.php
@@ -351,7 +351,7 @@ class WC_Amazon_Payments_Advanced_Admin {
 			'home_url'              => home_url( '', 'https' ),
 			'simple_path_url'       => wc_apa()->onboarding_handler->get_simple_path_registration_url(),
 			'public_key'            => WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() ? wc_apa()->onboarding_handler->get_public_key() : wc_apa()->onboarding_handler->get_public_key( false, true ),
-			'privacy_url'           => get_option( 'wp_page_for_privacy_policy' ) ? get_permalink( (int) get_option( 'wp_page_for_privacy_policy' ) ) : '',
+			'privacy_url'           => get_privacy_policy_url(),
 			'description'           => WC_Amazon_Payments_Advanced::get_site_description(),
 			'ajax_url'              => admin_url( 'admin-ajax.php' ),
 			'credentials_nonce'     => wp_create_nonce( 'amazon_pay_check_credentials' ),


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The correct function to get the privacy policy url is this: https://developer.wordpress.org/reference/functions/get_privacy_policy_url/
If you are using a privacy plugin, such as "GDPR Cookie Consent" or other related, the URL can be changed in the plugin itself using the filter: privacy_policy_url, in which case the previous version would not work.

Closes: https://app.clickup.com/t/86duwfma8

### How to test the changes in this Pull Request:

1. Start the onboarding process
2. Verify that the URL for the privacy policy page is correct

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix the URL for the privacy policy page
