### PR TITLE
disable editing the address if the user is logged in

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -192,7 +192,6 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'validate_api_keys' ) );
 
 		add_action( 'woocommerce_amazon_checkout_init', array( $this, 'checkout_init_common' ) );
-
 	}
 
 	/**

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-abstract.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-abstract.php
@@ -23,24 +23,6 @@ abstract class WC_Amazon_Payments_Advanced_Block_Compat_Abstract extends Abstrac
 		if ( ! isset( $this->name ) || ! isset( $this->settings_name ) ) {
 			throw new Exception( 'You have to set both the properties name and settings_name when extending the class ' . __CLASS__ . ' !' );
 		}
-
-		add_action( 'woocommerce_amazon_checkout_init', array( $this, 'initialize_express_session' ) );
-	}
-
-
-	/**
-	 * Actions to run when the Amazon Checkout session is initialized.
-	 *
-	 * @return void
-	 */
-	public function initialize_express_session() {
-		// Always ship to billing address.
-		add_filter(
-			'option_woocommerce_ship_to_destination',
-			function () {
-				return 'billing_only';
-			}
-		);
 	}
 
 

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-abstract.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-abstract.php
@@ -23,7 +23,26 @@ abstract class WC_Amazon_Payments_Advanced_Block_Compat_Abstract extends Abstrac
 		if ( ! isset( $this->name ) || ! isset( $this->settings_name ) ) {
 			throw new Exception( 'You have to set both the properties name and settings_name when extending the class ' . __CLASS__ . ' !' );
 		}
+
+		add_action( 'woocommerce_amazon_checkout_init', array( $this, 'initialize_express_session' ) );
 	}
+
+
+	/**
+	 * Actions to run when the Amazon Checkout session is initialized.
+	 *
+	 * @return void
+	 */
+	public function initialize_express_session() {
+		// Always ship to billing address.
+		add_filter(
+			'option_woocommerce_ship_to_destination',
+			function () {
+				return 'billing_only';
+			}
+		);
+	}
+
 
 	/**
 	 * Gets called during the server side initialization and sets our settings.

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php
@@ -65,7 +65,6 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Express extends WC_Amazon_Payment
 				'amazonShipping' => $checkout_session && ! is_wp_error( $checkout_session ) && ! empty( $checkout_session->shippingAddress ) ? WC_Amazon_Payments_Advanced_API::format_address( $checkout_session->shippingAddress ) : null, // phpcs:ignore WordPress.NamingConventions
 			),
 		);
-
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "woocommerce-gateway-amazon-payments-advanced",
-      "version": "2.5.1",
+      "version": "2.5.4",
       "hasInstallScript": true,
       "license": "GPL-2.0",
       "dependencies": {

--- a/src/js/_utils.js
+++ b/src/js/_utils.js
@@ -121,3 +121,16 @@ export const getCheckOutFieldsLabel = ( field, billingOrShipping ) => {
 export const amazonPayCanMakePayment = ( { cartTotals }, { allowedCurrencies } ) => {
 	return allowedCurrencies && allowedCurrencies.length > 0 ? allowedCurrencies.includes( cartTotals.currency_code ) : true;
 };
+
+
+/**
+ * Maybe removes the edit button from the address card.
+ */
+export const maybeRemoveEditButton = () => {
+	const editAddressButton = document.querySelectorAll('.wc-block-components-address-card__edit');
+    if ( editAddressButton && editAddressButton.length > 0 ) {
+        editAddressButton.forEach( ( button ) => {
+            button.remove();
+        } );
+    }
+}

--- a/src/js/payments-methods/express/_payment-methods.js
+++ b/src/js/payments-methods/express/_payment-methods.js
@@ -1,15 +1,17 @@
 /**
  * External dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import React from 'react';
+import { useDispatch } from '@wordpress/data';
+const { checkoutStore } = window.wc.wcBlocksData || false;
 
 /**
  * Internal dependencies
  */
-import { getCheckOutFieldsLabel } from '../../_utils';
+import { getCheckOutFieldsLabel, maybeRemoveEditButton } from '../../_utils';
 import { activateChange } from '../../_renderAmazonButton';
 import { settings } from './_settings';
  
@@ -38,11 +40,25 @@ const ChangePayment = () => {
  * @returns React component
  */
 const AmazonPayInfo = ( props ) => {
-    const { shippingAddress, setShippingAddress } = props.shippingData;
+    const { shippingAddress } = props.shippingData;
 
     const { billingData } = props.billing;
 
     const { amazonBilling, amazonShipping } = settings.amazonAddress;
+
+    const store = checkoutStore ? useDispatch( checkoutStore ) : null;
+
+    useEffect( () => {
+        const maybeDisableEditAddress = async () => {
+            maybeRemoveEditButton();
+            await store.setEditingBillingAddress( false );
+            await store.setEditingShippingAddress( false );
+        };
+
+        if ( store && settings.loggedIn ) {
+            maybeDisableEditAddress();
+        }
+    } );
 
     useEffect( () => {
         const unsubscribe = props.eventRegistration.onCheckoutValidation(

--- a/src/js/payments-methods/express/index.js
+++ b/src/js/payments-methods/express/index.js
@@ -13,7 +13,7 @@ const { registerCheckoutBlock } = wc.blocksCheckout;
  */
 import { PAYMENT_METHOD_NAME as PAYMENT_METHOD_NAME_EXPRESS } from './_constants';
 import { PAYMENT_METHOD_NAME } from '../classic/_constants';
-import { AmazonComponent, AmazonPayPreview, Label, amazonPayCanMakePayment } from '../../_utils';
+import { AmazonComponent, AmazonPayPreview, Label, amazonPayCanMakePayment, maybeRemoveEditButton } from '../../_utils';
 import { AmazonExpressContent } from './_payment-methods-express';
 import { AmazonContent } from './_payment-methods';
 import { settings } from './_settings';


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:
Prevents the users from editing their address on the Checkout block after they are logged in to Amazon.

### How to test the changes in this Pull Request:
1. Configure the Checkout using the block, not the legacy shortcode.
2. Navigate to the checkout page and log in using the Amazon Express button
3. The address should not be editable.

### Changelog entry
- Prevent address editing when user is logged with Amazon Express (Checkout Blocks)
