### PR TITLE
Validate openssl keys

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-merchant-onboarding-handler.php
+++ b/includes/class-wc-amazon-payments-advanced-merchant-onboarding-handler.php
@@ -199,6 +199,9 @@ class WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler {
 				'private_key_type' => self::PRIVATE_KEY_TYPE,
 			)
 		);
+		if ( false === $keys ) {
+			throw new Exception( esc_html__( 'Failed to generate OpenSSL key pair.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+		}
 
 		$public_key = openssl_pkey_get_details( $keys );
 		openssl_pkey_export( $keys, $private_key );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?  
* [x] Have you written new tests for your changes, as applicable?  
* [x] Have you successfully run tests with your changes locally?

---

### Changes proposed in this Pull Request:

Adds error handling to the `generate_keys()` method to avoid fatal errors when the OpenSSL key pair generation fails. This prevents the method from continuing with invalid data and provides a clear exception message, improving the reliability and debuggability of the code.

Closes # https://app.clickup.com/t/86dvpnaj6

---

### How to test the changes in this Pull Request:

1. Temporarily disable the OpenSSL extension on your local PHP environment (e.g. via `php.ini`) or simulate a failure using mocks.
2. Trigger the function that calls `generate_keys()`.
3. Confirm that the exception is thrown with the appropriate message:  
   `"Failed to generate OpenSSL key pair."`  
   instead of a fatal error or white screen.

---

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

---

### Changelog entry

> Add error handling for OpenSSL key generation failure in `generate_keys()` method to prevent fatal errors and improve stability.