### PR TITLE
Validate array session

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2020,6 +2020,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		foreach ( $desired as $prop => $value ) {
 			array_push( $path, $prop );
+
+			if ( ! isset( $current[ $prop ] ) ) {
+				continue;
+			}
+
 			if ( is_object( $value ) ) {
 				$valid = $this->validate_session_properties( $current[ $prop ], $value, $path );
 			} elseif ( is_array( $value ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?  
* [ ] Have you written new tests for your changes, as applicable?  
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

---

### Changes proposed in this Pull Request:

This PR updates the `validate_session_properties()` method to gracefully skip over invalid or undefined keys in the `$current` array during validation, rather than throwing a PHP warning or failing the entire validation process.

Specifically, it avoids validating keys from `$desired` that do not exist in `$current` (such as `"--"`), by adding an `isset()` check and using `continue` to proceed with the next item in the loop.

Closes #306

---

### How to test the changes in this Pull Request:

1. Trigger an Amazon Pay checkout session using WooCommerce with the Amazon Gateway plugin.
2. Log a case where the API returns unexpected keys like `"--"` in the payload.
3. Confirm that no PHP warnings like `Undefined array key "--"` are logged, and that other session properties still validate correctly.

---

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

---

### Changelog entry

> Fix – Skip undefined array keys during Amazon Pay session property validation to prevent PHP warnings and improve robustness against malformed payloads.
