### PR TITLE
Fix issues with QTI Test

### DIFF
--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -27,11 +27,11 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 	public function order_actions() {
 		check_ajax_referer( 'amazon_order_action', 'security' );
 
-		$order_id = absint( $_POST['order_id'] );
+		$order_id = isset( $_POST['order_id'] ) ? absint( wp_unslash( $_POST['order_id'] ) ) : 0;
 		$order    = wc_get_order( $order_id );
 		$version  = WC_Amazon_Payments_Advanced::get_order_version( $order_id );
-		$id       = isset( $_POST['amazon_id'] ) ? wc_clean( $_POST['amazon_id'] ) : '';
-		$action   = sanitize_title( $_POST['amazon_action'] );
+		$id       = isset( $_POST['amazon_id'] ) ? sanitize_text_field( wp_unslash( $_POST['amazon_id'] ) ) : '';
+		$action   = isset( $_POST['amazon_action'] ) ? sanitize_title( wp_unslash( $_POST['amazon_action'] ) ) : '';
 
 		do_action( 'wc_amazon_do_order_action', $order, $id, $action, $version );
 
@@ -77,8 +77,8 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 
 		$version = WC_Amazon_Payments_Advanced::get_order_version( $order_id );
 
-		$id     = isset( $_GET['amazon_id'] ) ? wc_clean( $_GET['amazon_id'] ) : '';
-		$action = sanitize_title( $_GET['amazon_action'] );
+		$id     = isset( $_GET['amazon_id'] ) ? sanitize_text_field( wp_unslash( $_GET['amazon_id'] ) ) : '';
+		$action = sanitize_title( wp_unslash( $_GET['amazon_action'] ) );
 
 		do_action( 'wc_amazon_do_order_action', $order, $id, $action, $version );
 

--- a/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
+++ b/includes/admin/legacy/class-wc-amazon-payments-advanced-order-admin-legacy.php
@@ -83,8 +83,15 @@ class WC_Amazon_Payments_Advanced_Order_Admin_Legacy {
 				// $id is capture reference.
 				wc_apa()->log( 'Info: Trying to refund payment with capture reference ' . $id );
 				// phpcs:disable WordPress.Security.NonceVerification.Missing
-				$amazon_refund_amount = floatval( wc_clean( $_POST['amazon_refund_amount'] ) );
-				$amazon_refund_note   = wc_clean( $_POST['amazon_refund_note'] );
+				$amazon_refund_amount = 0;
+				if ( isset( $_POST['amazon_refund_amount'] ) ) {
+					$amazon_refund_amount = floatval( sanitize_text_field( wp_unslash( $_POST['amazon_refund_amount'] ) ) );
+				}
+
+				$amazon_refund_note = '';
+				if ( isset( $_POST['amazon_refund_note'] ) ) {
+					$amazon_refund_note = sanitize_text_field( wp_unslash( $_POST['amazon_refund_note'] ) );
+				}
 				// phpcs:enable WordPress.Security.nonceVerification.Missing
 				WC_Amazon_Payments_Advanced_API_Legacy::refund_payment( $order_id, $id, $amazon_refund_amount, $amazon_refund_note );
 				wc_create_refund(

--- a/includes/class-wc-amazon-payments-advanced-ipn-handler-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-ipn-handler-abstract.php
@@ -40,7 +40,7 @@ abstract class WC_Amazon_Payments_Advanced_IPN_Handler_Abstract {
 					$key = $key[0];
 				}
 
-				throw new Exception( $key . ' is required to verify the SNS message.' );
+				throw new Exception( esc_html( $key ) . ' is required to verify the SNS message.' );
 			}
 		}
 	}

--- a/includes/class-wc-amazon-payments-advanced-ipn-handler.php
+++ b/includes/class-wc-amazon-payments-advanced-ipn-handler.php
@@ -133,7 +133,12 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 	 */
 	protected function validate_message( $message ) {
 		if ( ! function_exists( 'openssl_get_publickey' ) || ! function_exists( 'openssl_verify' ) ) {
-			throw new Exception( 'OpenSSL extension is not available in your server.' );
+			throw new Exception(
+				esc_html__(
+					'OpenSSL extension is not available on your server.',
+					'woocommerce-gateway-amazon-payments-advanced'
+				)
+			);
 		}
 
 		if ( $this->is_lambda_style( $message ) ) {
@@ -147,7 +152,12 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 		// Extract the public key.
 		$key = openssl_get_publickey( $certificate );
 		if ( ! $key ) {
-			throw new Exception( 'Cannot get the public key from the certificate.' );
+			throw new Exception(
+				esc_html__(
+					'Cannot get the public key from the certificate.',
+					'woocommerce-gateway-amazon-payments-advanced'
+				)
+			);
 		}
 
 		// Verify the signature of the message.
@@ -155,7 +165,12 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 		$signature = base64_decode( $message['Signature'] ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 
 		if ( 1 !== openssl_verify( $content, $signature, $key, OPENSSL_ALGO_SHA1 ) ) {
-			throw new Exception( 'The message signature is invalid.' );
+			throw new Exception(
+				esc_html__(
+					'The message signature is invalid.',
+					'woocommerce-gateway-amazon-payments-advanced'
+				)
+			);
 		}
 	}
 
@@ -217,7 +232,12 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 			|| 'https' !== $parsed_url['scheme']
 			|| '.pem' !== substr( $url, -4 )
 			|| ! preg_match( $this->host_pattern, $parsed_url['host'] ) ) {
-			throw new Exception( 'Invalid certificate URL.' );
+			throw new Exception(
+				esc_html__(
+					'Invalid certificate URL.',
+					'woocommerce-gateway-amazon-payments-advanced'
+				)
+			);
 		}
 	}
 
@@ -246,7 +266,12 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 		);
 
 		if ( self::SIGNATURE_VERSION_1 !== $message['SignatureVersion'] ) {
-			throw new Exception( 'The SignatureVersion ' . $message['SignatureVersion'] . ' is not supported.' );
+			throw new Exception(
+				sprintf(
+					esc_html__( 'The SignatureVersion %s is not supported.', 'woocommerce-gateway-amazon-payments-advanced' ),
+					esc_html( $message['SignatureVersion'] )
+				)
+			);
 		}
 
 		$string_to_sign = '';
@@ -289,7 +314,12 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 				do_action( 'woocommerce_amazon_payments_advanced_ipn_validate_subscription_keys', $message );
 				break;
 			default:
-				throw new Exception( 'No handler for message type ' . $message['Type'] );
+				throw new Exception(
+					sprintf(
+						esc_html__( 'No handler for message type %s', 'woocommerce-gateway-amazon-payments-advanced' ),
+						esc_html( $message['Type'] )
+					)
+				);
 		}
 
 		wc_apa()->log( sprintf( 'Valid IPN message %s.', $message['MessageId'] ) );
@@ -313,7 +343,12 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 		$message    = json_decode( $raw_post_data, true );
 		$json_error = json_last_error();
 		if ( JSON_ERROR_NONE !== $json_error || ! is_array( $message ) ) {
-			throw new Exception( 'Invalid POST data. Failed to decode the message: ' . $this->get_json_error_message( $json_error ) );
+			throw new Exception(
+				sprintf(
+					esc_html__( 'Invalid POST data. Failed to decode the message: %s', 'woocommerce-gateway-amazon-payments-advanced' ),
+					$this->get_json_error_message( $json_error )
+				)
+			);
 		}
 
 		return $message;
@@ -366,7 +401,7 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 
 		try {
 			if ( empty( $raw_post_data ) ) {
-				throw new Exception( 'Empty post data.' );
+				throw new Exception( esc_html__( 'Empty post data.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 			}
 
 			$message = $this->get_message_from_raw_post_data( $raw_post_data );
@@ -420,7 +455,7 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 					$charge_id = (string) $notification_data->RefundDetails->AmazonRefundId; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 					break;
 				default:
-					wc_apa()->log( 'No handler for notification with type ' . $message['Message']['NotificationType'], $notification_data );
+					wc_apa()->log( sprintf( 'No handler for notification with type %s', esc_html( $message['Message']['NotificationType'] ) ), $notification_data );
 					return;
 			}
 
@@ -455,7 +490,7 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 				$order_id = $charge->merchantMetadata->merchantReferenceId; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				break;
 			default:
-				throw new Exception( 'Not Implemented' );
+				throw new Exception( esc_html__( 'Not Implemented', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
 
 		$order_id = apply_filters( 'woocommerce_amazon_pa_merchant_metadata_reference_id_reverse', $order_id );
@@ -463,19 +498,33 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 		if ( is_numeric( $order_id ) ) {
 			$order = wc_get_order( $order_id );
 		} else {
-			throw new Exception( 'Invalid order ID ' . $order_id );
+			throw new Exception(
+				sprintf(
+					esc_html__( 'Invalid order ID %s.', 'woocommerce-gateway-amazon-payments-advanced' ),
+					esc_html( $order_id )
+				)
+			);
 		}
 
 		$order    = apply_filters( 'woocommerce_amazon_pa_ipn_notification_order', $order, $notification );
 		$order_id = $order->get_id(); // Refresh variable, in case it changed.
 
 		if ( 'amazon_payments_advanced' !== $order->get_payment_method() ) {
-			throw new Exception( 'Order ID ' . $order_id . ' is not paid with Amazon' );
+			throw new Exception(
+				sprintf(
+					esc_html__( 'Order ID %s is not paid with Amazon', 'woocommerce-gateway-amazon-payments-advanced' ),
+					esc_html( $order_id )
+				)
+			);
 		}
 
 		if ( 'STATE_CHANGE' !== strtoupper( $notification['NotificationType'] ) ) {
-			/* translators: 1) Notification Type. */
-			throw new Exception( sprintf( __( 'Notification type "%s" not supported', 'woocommerce-gateway-amazon-payments-advanced' ), $notification['NotificationType'] ) );
+			throw new Exception( 
+				sprintf( 
+					esc_html__( 'Notification type "%s" not supported', 'woocommerce-gateway-amazon-payments-advanced' ), 
+					esc_html( $notification['NotificationType'] ) 
+				) 
+			);
 		}
 
 		if ( ! wc_apa()->get_gateway()->get_lock_for_order( $order_id ) ) {
@@ -506,7 +555,9 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 				break;
 			default:
 				wc_apa()->get_gateway()->release_lock_for_order( $order_id );
-				throw new Exception( 'Not Implemented' );
+				throw new Exception( 
+					esc_html__( 'Not implemented.', 'woocommerce-gateway-amazon-payments-advanced' )
+				);
 		}
 
 		wc_apa()->get_gateway()->release_lock_for_order( $order_id );

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -394,7 +394,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 			),
 			'manual_notice'               => array(
 				'type' => 'custom',
-				'html' => '<p>Problems with automatic setup? Toggle here <a href="#" class="wcapa-toggle-section" data-toggle="#manual-settings-container, #automatic-settings-container"><span class="woocommerce-input-toggle woocommerce-input-toggle--disabled" aria-label="' . esc_attr( __( 'Manually enter your keys', 'woocommerce-gateway-amazon-payments-advanced' ) ) . '">' . esc_attr__( 'Yes', 'woocommerce' ) . '</span></a> to manually enter your keys.</p>',
+				'html' => '<p>Problems with automatic setup? Toggle here <a href="#" class="wcapa-toggle-section" data-toggle="#manual-settings-container, #automatic-settings-container"><span class="woocommerce-input-toggle woocommerce-input-toggle--disabled" aria-label="' . esc_attr( __( 'Manually enter your keys', 'woocommerce-gateway-amazon-payments-advanced' ) ) . '">' . esc_attr__( 'Yes', 'woocommerce-gateway-amazon-payments-advanced' ) . '</span></a> to manually enter your keys.</p>',
 			),
 			'manual_container_start'      => array(
 				'type' => 'custom',

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -437,9 +437,23 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		global $wpdb;
 		$this->maybe_create_index_table();
 
+		$cache_key = 'customer_id_for_buyer_' . $buyer_id;
+		$cached_customer_id = wp_cache_get( $cache_key, 'woocommerce_amazon_buyer_index' );
+
+		if ( false !== $cached_customer_id ) {
+			return intval( $cached_customer_id );
+		}
+
+		// This is a custom table, so we need to use a direct database query.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$customer_id = $wpdb->get_var( $wpdb->prepare( "SELECT customer_id FROM {$wpdb->prefix}woocommerce_amazon_buyer_index WHERE buyer_id = %s", $buyer_id ) );
 
-		return ! empty( $customer_id ) ? intval( $customer_id ) : false;
+		if ( ! empty( $customer_id ) ) {
+			wp_cache_set( $cache_key, $customer_id, 'woocommerce_amazon_buyer_index' );
+			return intval( $customer_id );
+		}
+
+		return false;
 	}
 
 	/**
@@ -453,6 +467,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		global $wpdb;
 		$this->maybe_create_index_table();
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$inserted = $wpdb->insert(
 			"{$wpdb->prefix}woocommerce_amazon_buyer_index",
 			array(
@@ -464,6 +479,10 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( ! $inserted ) {
 			return false;
 		}
+
+		// Invalidate cache for this buyer_id.
+		$cache_key = 'customer_id_for_buyer_' . $buyer_id;
+		wp_cache_delete( $cache_key, 'woocommerce_amazon_buyer_index' );
 
 		return true;
 	}
@@ -521,13 +540,13 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				}
 
 				if ( empty( $data['amazon_validate'] ) ) {
-					throw new Exception( __( 'You did not enter the password to validate your account. If you want, you can continue as guest.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+					throw new Exception( esc_html__( 'You did not enter the password to validate your account. If you want, you can continue as guest.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 				}
 
 				$user = get_user_by( 'id', $user_id );
 
 				if ( ! wp_check_password( $data['amazon_validate'], $user->user_pass, $user->ID ) ) {
-					throw new Exception( __( 'The password you entered did not match the one on the account. Try again, or continue as guest.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+					throw new Exception( esc_html__( 'The password you entered did not match the one on the account. Try again, or continue as guest.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 				}
 
 				$customer_id = $user_id;
@@ -576,7 +595,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 */
 	public function print_validate_button( $html ) {
 		$html  = '<p class="form-row" id="amazon_validate_notice_field" data-priority="">';
-		$html .= __( 'An account with your Amazon Pay email address exists already. Is that you? If so, enter your password below.', 'woocommerce-gateway-amazon-payments-advanced' );
+		$html .= esc_html__( 'An account with your Amazon Pay email address exists already. Is that you? If so, enter your password below.', 'woocommerce-gateway-amazon-payments-advanced' );
 		$html .= '</p>';
 		return $html;
 	}
@@ -674,7 +693,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( $this->is_available() ) {
 			if ( ! $this->is_logged_in() ) {
 				?>
-				<div class="woocommerce-info info wc-amazon-payments-advanced-info"><?php echo wp_kses_post( $this->checkout_button( false ) . ' ' . apply_filters( 'woocommerce_amazon_pa_checkout_message', __( 'Have an Amazon account?', 'woocommerce-gateway-amazon-payments-advanced' ) ) ); ?></div>
+				<div class="woocommerce-info info wc-amazon-payments-advanced-info"><?php echo wp_kses_post( $this->checkout_button( false ) . ' ' . apply_filters( 'woocommerce_amazon_pa_checkout_message', esc_html__( 'Have an Amazon account?', 'woocommerce-gateway-amazon-payments-advanced' ) ) ); ?></div>
 				<?php
 			} else {
 				$this->logout_checkout_message();
@@ -691,7 +710,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 */
 	public function logout_checkout_message() {
 		$logout_url      = $this->get_amazon_logout_url();
-		$logout_msg_html = '<div class="woocommerce-info info">' . apply_filters( 'woocommerce_amazon_pa_checkout_logout_message', __( 'You\'re logged in with your Amazon Account.', 'woocommerce-gateway-amazon-payments-advanced' ) ) . ' <a href="' . esc_url( $logout_url ) . '" id="amazon-logout">' . __( 'Log out &raquo;', 'woocommerce-gateway-amazon-payments-advanced' ) . '</a></div>';
+		$logout_msg_html = '<div class="woocommerce-info info">' . apply_filters( 'woocommerce_amazon_pa_checkout_logout_message', esc_html__( 'You\'re logged in with your Amazon Account.', 'woocommerce-gateway-amazon-payments-advanced' ) ) . ' <a href="' . esc_url( $logout_url ) . '" id="amazon-logout">' . esc_html__( 'Log out &raquo;', 'woocommerce-gateway-amazon-payments-advanced' ) . '</a></div>';
 		echo wp_kses_post( apply_filters( 'woocommerce_amazon_payments_logout_checkout_message_html', $logout_msg_html ) );
 	}
 
@@ -764,7 +783,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( ! empty( $_GET['amazon_return_classic'] ) && ! empty( $_GET['amazonCheckoutSessionId'] ) ) {
 			$redirect_url = remove_query_arg( array( 'amazon_return_classic', 'amazonCheckoutSessionId' ), $redirect_url );
 
-			$this->handle_return( sanitize_text_field( $_GET['amazonCheckoutSessionId'] ) );
+			$this->handle_return( sanitize_text_field( wp_unslash( $_GET['amazonCheckoutSessionId'] ) ) );
 			// If we didn't redirect and quit yet, lets force redirect to checkout.
 			wp_safe_redirect( $redirect_url );
 			exit;
@@ -784,7 +803,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( isset( $_GET['amazon_login'] ) && isset( $_GET['amazonCheckoutSessionId'] ) ) {
 			$redirect_url = remove_query_arg( array( 'amazon_login', 'amazonCheckoutSessionId' ), $redirect_url );
 			$session_key  = $this->get_checkout_session_key();
-			WC()->session->set( $session_key, sanitize_text_field( $_GET['amazonCheckoutSessionId'] ) );
+			WC()->session->set( $session_key, sanitize_text_field( wp_unslash( $_GET['amazonCheckoutSessionId'] ) ) );
 			$this->unset_force_refresh();
 			WC()->session->save_data();
 
@@ -807,7 +826,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( isset( $_GET['amazon_return'] ) && isset( $_GET['amazonCheckoutSessionId'] ) ) {
 			$redirect_url = remove_query_arg( array( 'amazon_return', 'amazonCheckoutSessionId' ), $redirect_url );
 			if ( $_GET['amazonCheckoutSessionId'] !== $this->get_checkout_session_id() ) {
-				wc_add_notice( __( 'There was an error after returning from Amazon. Please try again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+				wc_add_notice( esc_html__( 'There was an error after returning from Amazon. Please try again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 				wp_safe_redirect( $redirect_url );
 				exit;
 			}
@@ -983,7 +1002,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$checkout_fields['account']['amazon_validate'] = array(
 			'type'     => 'password',
-			'label'    => __( 'Password', 'woocommerce' ), // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+			'label'    => esc_html__( 'Password', 'woocommerce-gateway-amazon-payments-advanced' ),
 			'required' => true,
 		);
 
@@ -1027,9 +1046,9 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		?>
 		<div id="payment_method_widget">
 			<?php
-			$change_label = __( 'Change', 'woocommerce-gateway-amazon-payments-advanced' );
+			$change_label = esc_html__( 'Change', 'woocommerce-gateway-amazon-payments-advanced' );
 			if ( ! $this->has_payment_preferences( $checkout_session ) ) {
-				$change_label = __( 'Select', 'woocommerce-gateway-amazon-payments-advanced' );
+				$change_label = esc_html__( 'Select', 'woocommerce-gateway-amazon-payments-advanced' );
 			}
 
 			?>
@@ -1204,7 +1223,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 									$key,
 									array(
 										'type'  => 'checkbox',
-										'label' => __( 'Link Amazon Pay Account', 'woocommerce-gateway-amazon-payments-advanced' ),
+										'label' => esc_html__( 'Link Amazon Pay Account', 'woocommerce-gateway-amazon-payments-advanced' ),
 									),
 									$value
 								);
@@ -1286,7 +1305,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		$data = array_merge( $data, array_intersect_key( $formatted_session_data, $data ) ); // only set data that exists in data.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_REQUEST['amazon_link'] ) ) {
-			$data['amazon_link'] = esc_url_raw( $_REQUEST['amazon_link'] );
+			$data['amazon_link'] = esc_url_raw( wp_unslash( $_REQUEST['amazon_link'] ) );
 		}
 
 		return $data;
@@ -1322,7 +1341,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		switch ( $input ) {
 			case 'amazon_link':
 				if ( isset( $_REQUEST[ $input ] ) ) {
-					return sanitize_text_field( $_REQUEST[ $input ] );
+					return sanitize_text_field( wp_unslash( $_REQUEST[ $input ] ) );
 				}
 				break;
 			default:
@@ -1359,7 +1378,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			return;
 		}
 
-		$errors->add( 'amazon-pay-classic', __( 'A phone number is required to complete your checkout through Amazon Pay.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+		$errors->add( 'amazon-pay-classic', esc_html__( 'A phone number is required to complete your checkout through Amazon Pay.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 	}
 
 	/**
@@ -1387,13 +1406,13 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		try {
 			if ( ! $order ) {
-				throw new Exception( __( 'Invalid order.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+				throw new Exception( esc_html__( 'Invalid order.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 			}
 
 			$doing_classic_payment = empty( $checkout_session_id );
 
 			if ( empty( $payments ) && ! $doing_classic_payment ) {
-				throw new Exception( __( 'An Amazon Pay payment method was not chosen.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+				throw new Exception( esc_html__( 'An Amazon Pay payment method was not chosen.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 			}
 
 			/**
@@ -1467,13 +1486,13 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 				if ( is_wp_error( $response ) ) {
 					wc_apa()->log( "Error processing payment for order {$order_id}. Checkout Session ID: {$checkout_session_id}", $response );
-					wc_add_notice( __( 'There was an error while processing your payment. Your payment method was not charged. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+					wc_add_notice( esc_html__( 'There was an error while processing your payment. Your payment method was not charged. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 					return array();
 				}
 
 				if ( ! empty( $response->constraints ) ) {
 					wc_apa()->log( "Error processing payment for order {$order_id}. Checkout Session ID: {$checkout_session_id}.", $response->constraints );
-					wc_add_notice( __( 'There was an error while processing your payment. Your payment method was not charged. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+					wc_add_notice( esc_html__( 'There was an error while processing your payment. Your payment method was not charged. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 					return array();
 				}
 				$redirect = $response->webCheckoutDetails->amazonPayRedirectUrl; // phpcs:ignore WordPress.NamingConventions
@@ -1484,7 +1503,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				if ( ! empty( wc_apa()->get_subscriptions() ) && wc_apa()->get_subscriptions()->is_subs_change_payment() ) {
 					$redirect = ! empty( $payload['webCheckoutDetails']['checkoutResultReturnUrl'] ) ? $payload['webCheckoutDetails']['checkoutResultReturnUrl'] : $order->get_change_payment_method_url();
 				} else {
-					$order->update_status( 'pending', __( 'Awaiting payment.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+					$order->update_status( 'pending', esc_html__( 'Awaiting payment.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 					$redirect = '#';
 				}
 			}
@@ -1511,7 +1530,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 			return $result;
 		} catch ( Exception $e ) {
-			wc_add_notice( __( 'Error:', 'woocommerce-gateway-amazon-payments-advanced' ) . ' ' . $e->getMessage(), 'error' );
+			wc_add_notice( esc_html__( 'Error:', 'woocommerce-gateway-amazon-payments-advanced' ) . ' ' . $e->getMessage(), 'error' );
 		}
 		return array();
 	}
@@ -1572,7 +1591,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		if ( empty( $order_id ) ) {
 			wc_apa()->log( "Error: Order could not be found. Checkout Session ID: {$checkout_session_id}." );
-			wc_add_notice( __( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+			wc_add_notice( esc_html__( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 			return;
 		}
 
@@ -1583,7 +1602,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		if ( ! $this->maybe_update_order_addresses( $order, $checkout_session, $checkout_session_id ) ) {
 			wc_apa()->log( "Error: Order address mismatch and could not be updated. Checkout Session ID: {$checkout_session_id}." );
-			wc_add_notice( __( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+			wc_add_notice( esc_html__( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 			return;
 		}
 
@@ -1616,17 +1635,17 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				$reason_code = $checkout_session->statusDetails->reasonCode; // phpcs:ignore WordPress.NamingConventions
 				$order->add_order_note(
 					sprintf(
-						__( 'Amazon Pay checkout was canceled. Reason(s): %s', 'woocommerce-gateway-amazon-payments-advanced' ),
-						$reason_code ? $reason_code : __( 'Unknown', 'woocommerce-gateway-amazon-payments-advanced' )
+						esc_html__( 'Amazon Pay checkout was canceled. Reason(s): %s', 'woocommerce-gateway-amazon-payments-advanced' ),
+						$reason_code ? $reason_code : esc_html__( 'Unknown', 'woocommerce-gateway-amazon-payments-advanced' )
 					)
 				);
 
 				switch ( $reason_code ) {
 					case 'Declined':
-						wc_add_notice( __( 'There was a problem with previously declined transaction. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+						wc_add_notice( esc_html__( 'There was a problem with previously declined transaction. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 						break;
 					case 'BuyerCanceled':
-						wc_add_notice( __( 'The transaction was canceled by you. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+						wc_add_notice( esc_html__( 'The transaction was canceled by you. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 						break;
 					default:
 						$detail_debug = array(
@@ -1634,13 +1653,13 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 							'checkout_session' => $checkout_session,
 						);
 						wc_apa()->log( "Error processing payment for order {$order_id}. Checkout Session ID: {$checkout_session_id}.", $detail_debug );
-						wc_add_notice( __( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+						wc_add_notice( esc_html__( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 						break;
 				}
 
-				$this->do_force_refresh( __( 'Click the button below to select another payment method', 'woocommerce-gateway-amazon-payments-advanced' ) );
+				$this->do_force_refresh( esc_html__( 'Click the button below to select another payment method', 'woocommerce-gateway-amazon-payments-advanced' ) );
 			} else {
-				wc_add_notice( __( 'Error:', 'woocommerce-gateway-amazon-payments-advanced' ) . ' ' . $response->get_error_message(), 'error' );
+				wc_add_notice( esc_html__( 'Error:', 'woocommerce-gateway-amazon-payments-advanced' ) . ' ' . $response->get_error_message(), 'error' );
 			}
 			$this->release_lock_for_order( $order_id );
 			return;
@@ -1649,7 +1668,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( 'Completed' !== $response->statusDetails->state ) { // phpcs:ignore WordPress.NamingConventions
 			// ASK: Ask for posibilities of status not to be completed at this stage.
 			wc_apa()->log( "Error processing payment for order {$order_id}. Checkout Session ID: {$checkout_session_id}.", $response->statusDetails ); // phpcs:ignore WordPress.NamingConventions
-			wc_add_notice( __( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+			wc_add_notice( esc_html__( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 			$this->release_lock_for_order( $order_id );
 			return;
 		}
@@ -1800,7 +1819,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		$order->add_order_note(
 			sprintf(
 				/* translators: 1) Amazon Charge ID 2) Charge status */
-				__( 'Charge %1$s with status %2$s.', 'woocommerce-gateway-amazon-payments-advanced' ),
+				esc_html__( 'Charge %1$s with status %2$s.', 'woocommerce-gateway-amazon-payments-advanced' ),
 				(string) $charge_id,
 				(string) $charge_status
 			)
@@ -1904,7 +1923,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			case 'Closed':
 				$order_has_charge = is_null( $this->get_cached_charge_status( $order, true )->status );
 				if ( apply_filters( 'woocommerce_amazon_pa_charge_permission_status_should_fail_order', $order_has_charge, $order ) ) {
-					$order->update_status( 'failed', __( 'Amazon charge status was closed, moving order to failed.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+					$order->update_status( 'failed', esc_html__( 'Amazon charge status was closed, moving order to failed.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 					wc_maybe_increase_stock_levels( $order->get_id() );
 				}
 				break;
@@ -1929,7 +1948,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		// @codingStandardsIgnoreStart
 		$order->add_order_note( sprintf(
 			/* translators: 1) Amazon Charge ID 2) Charge status */
-			__( 'Charge Permission %1$s with status %2$s.', 'woocommerce-gateway-amazon-payments-advanced' ),
+			esc_html__( 'Charge Permission %1$s with status %2$s.', 'woocommerce-gateway-amazon-payments-advanced' ),
 			(string) $charge_permission_id,
 			(string) $new_status
 		) );
@@ -2044,7 +2063,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				<p class="wc_apa_login_again_text">
 				<?php
 				if ( empty( $message ) ) {
-					$message = __( 'Your cart changed, and you need to confirm your selected payment method again.', 'woocommerce-gateway-amazon-payments-advanced' );
+					$message = esc_html__( 'Your cart changed, and you need to confirm your selected payment method again.', 'woocommerce-gateway-amazon-payments-advanced' );
 				}
 
 				echo esc_html( $message );
@@ -2163,15 +2182,15 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$props_validation = $this->validate_session_properties( $checkout_session );
 		if ( is_wp_error( $props_validation ) ) {
-			return new WP_Error( 'session_changed', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $props_validation->get_error_data() );
+			return new WP_Error( 'session_changed', esc_html__( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $props_validation->get_error_data() );
 		}
 
 		if ( 'Open' !== $checkout_session->statusDetails->state ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			return new WP_Error( 'not_open', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $checkout_session->statusDetails->state ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			return new WP_Error( 'not_open', esc_html__( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $checkout_session->statusDetails->state ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 
 		if ( $checkout_session->productType !== $this->get_current_cart_action() ) { // phpcs:ignore WordPress.NamingConventions
-			return new WP_Error( 'product_type_changed', __( 'Your cart changed, and you need to confirm your selected payment method again.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+			return new WP_Error( 'product_type_changed', esc_html__( 'Your cart changed, and you need to confirm your selected payment method again.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
 		return apply_filters( 'woocommerce_amazon_pa_is_checkout_session_still_valid', true, $checkout_session );
 	}
@@ -2199,12 +2218,12 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	public function process_admin_options() {
 		if ( check_admin_referer( 'woocommerce-settings' ) ) {
 			if ( ! empty( $_POST['woocommerce_amazon_payments_advanced_button_language'] ) ) {
-				$region   = sanitize_text_field( $_POST['woocommerce_amazon_payments_advanced_payment_region'] );
-				$language = sanitize_text_field( $_POST['woocommerce_amazon_payments_advanced_button_language'] );
+				$region   = isset( $_POST['woocommerce_amazon_payments_advanced_payment_region'] ) ? sanitize_text_field( wp_unslash( $_POST['woocommerce_amazon_payments_advanced_payment_region'] ) ) : '';
+				$language = sanitize_text_field( wp_unslash( $_POST['woocommerce_amazon_payments_advanced_button_language'] ) );
 				$regions  = WC_Amazon_Payments_Advanced_API::get_languages_per_region();
 				if ( ! isset( $regions[ $region ] ) || ! in_array( $language, $regions[ $region ], true ) ) {
 					/* translators: 1) Language 2) Region */
-					WC_Admin_Settings::add_error( sprintf( __( '%1$s is not a valid language for the %2$s region.', 'woocommerce-gateway-amazon-payments-advanced' ), $language, WC_Amazon_Payments_Advanced_API::get_region_label( $region ) ) );
+					WC_Admin_Settings::add_error( sprintf( esc_html__( '%1$s is not a valid language for the %2$s region.', 'woocommerce-gateway-amazon-payments-advanced' ), $language, WC_Amazon_Payments_Advanced_API::get_region_label( $region ) ) );
 					$_POST['woocommerce_amazon_payments_advanced_button_language'] = '';
 				}
 			}
@@ -2779,24 +2798,25 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				WC()->customer->save();
 
 				if ( ! empty( $_POST['terms-field'] ) && empty( $_POST['terms'] ) ) {
-					wc_add_notice( __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+					wc_add_notice( esc_html__( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 					self::send_ajax_failure_response();
 				}
 
 				// Update payment method.
 				if ( $order->needs_payment() ) {
 					try {
+						// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 						$payment_method_id = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : false;
 
 						if ( ! $payment_method_id ) {
-							throw new Exception( __( 'Invalid payment method.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+							throw new Exception( esc_html__( 'Invalid payment method.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 						}
 
 						$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
 						$payment_method     = isset( $available_gateways[ $payment_method_id ] ) ? $available_gateways[ $payment_method_id ] : false;
 
 						if ( ! $payment_method ) {
-							throw new Exception( __( 'Invalid payment method.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+							throw new Exception( esc_html__( 'Invalid payment method.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 						}
 
 						$order->set_payment_method( $payment_method );
@@ -3139,8 +3159,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		$args = array();
 		// phpcs:disable WordPress.Security.NonceVerification
 		if ( isset( $_GET['switch-subscription'] ) && isset( $_GET['item'] ) && isset( $_GET['_wcsnonce'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$args['switch-subscription'] = wc_clean( wp_unslash( $_GET['switch-subscription'] ) );
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$args['item']                = wc_clean( wp_unslash( $_GET['item'] ) );
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$args['_wcsnonce']           = wc_clean( wp_unslash( $_GET['_wcsnonce'] ) );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-ppbc.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-ppbc.php
@@ -50,7 +50,7 @@ class WC_Amazon_Payments_Advanced_Multi_Currency_PPBC extends WC_Amazon_Payments
 		// This is for sandbox mode, changing countries manually.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_REQUEST['wcpbc-manual-country'] ) ) {
-			$manual_country = wc_clean( wp_unslash( $_REQUEST['wcpbc-manual-country'] ) );
+			$manual_country = sanitize_text_field( wp_unslash( $_REQUEST['wcpbc-manual-country'] ) );
 			$selected_zone  = WCPBC_Pricing_Zones::get_zone_by_country( $manual_country );
 		} else {
 			$selected_zone = wcpbc_get_zone_by_country();

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
@@ -51,7 +51,7 @@ class WC_Amazon_Payments_Advanced_Multi_Currency {
 		// Load multicurrency fields if compatibility. (Only on settings admin).
 		if ( is_admin() ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$compatible_region = isset( $_POST['woocommerce_amazon_payments_advanced_payment_region'] ) ? self::compatible_region( sanitize_text_field( $_POST['woocommerce_amazon_payments_advanced_payment_region'] ) ) : self::compatible_region();
+			$compatible_region = isset( $_POST['woocommerce_amazon_payments_advanced_payment_region'] ) ? self::compatible_region( sanitize_text_field( wp_unslash( $_POST['woocommerce_amazon_payments_advanced_payment_region'] ) ) ) : self::compatible_region();
 			if ( $compatible_region ) {
 				add_filter( 'woocommerce_amazon_pa_form_fields_before_legacy', array( __CLASS__, 'add_currency_fields' ) );
 			}

--- a/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
+++ b/includes/legacy/class-wc-amazon-payments-advanced-api-legacy.php
@@ -383,11 +383,11 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 */
 	public static function get_reference_id() {
 		//phpcs:disable WordPress.Security.NonceVerification
-		$reference_id = ! empty( $_REQUEST['amazon_reference_id'] ) ? sanitize_text_field( $_REQUEST['amazon_reference_id'] ) : '';
+		$reference_id = ! empty( $_REQUEST['amazon_reference_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['amazon_reference_id'] ) ) : '';
 
 		if ( isset( $_POST['post_data'] ) ) {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			parse_str( $_POST['post_data'], $post_data );
+			parse_str( wp_unslash( $_POST['post_data'] ), $post_data );
 
 			if ( isset( $post_data['amazon_reference_id'] ) ) {
 				$reference_id = $post_data['amazon_reference_id'];
@@ -405,7 +405,7 @@ class WC_Amazon_Payments_Advanced_API_Legacy extends WC_Amazon_Payments_Advanced
 	 */
 	public static function get_access_token() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$access_token = ! empty( $_REQUEST['access_token'] ) ? sanitize_text_field( $_REQUEST['access_token'] ) : ( isset( $_COOKIE['amazon_Login_accessToken'] ) && ! empty( $_COOKIE['amazon_Login_accessToken'] ) ? sanitize_text_field( $_COOKIE['amazon_Login_accessToken'] ) : '' );
+		$access_token = ! empty( $_REQUEST['access_token'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['access_token'] ) ) : ( isset( $_COOKIE['amazon_Login_accessToken'] ) && ! empty( $_COOKIE['amazon_Login_accessToken'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['amazon_Login_accessToken'] ) ) : '' );
 
 		return self::check_session( 'access_token', $access_token );
 	}

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-legacy.php
@@ -119,7 +119,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 			<?php if ( empty( $this->reference_id ) && empty( $this->access_token ) ) : ?>
 				<div>
 					<div id="pay_with_amazon"></div>
-					<?php echo esc_html( apply_filters( 'woocommerce_amazon_pa_checkout_message', __( 'Have an Amazon account?', 'woocommerce-gateway-amazon-payments-advanced' ) ) ); ?>
+					<?php echo esc_html( apply_filters( 'woocommerce_amazon_pa_checkout_message', esc_html__( 'Have an Amazon account?', 'woocommerce-gateway-amazon-payments-advanced' ) ) ); ?>
 				</div>
 			<?php else : ?>
 				<div class="wc-amazon-payments-advanced-order-day-widgets">
@@ -287,15 +287,15 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		}
 
 		$order               = wc_get_order( $order_id );
-		$amazon_reference_id = isset( $_POST['amazon_reference_id'] ) ? wc_clean( $_POST['amazon_reference_id'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$amazon_reference_id = isset( $_POST['amazon_reference_id'] ) ? wc_clean( wp_unslash( $_POST['amazon_reference_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		try {
 			if ( ! $order ) {
-				throw new Exception( __( 'Invalid order.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+				throw new Exception( esc_html__( 'Invalid order.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 			}
 
 			if ( ! $amazon_reference_id ) {
-				throw new Exception( __( 'An Amazon Pay payment method was not chosen.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+				throw new Exception( esc_html__( 'An Amazon Pay payment method was not chosen.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 			}
 
 			/**
@@ -405,7 +405,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 					'redirect' => $this->get_return_url( $order ),
 				);
 			}
-			wc_add_notice( __( 'Error:', 'woocommerce-gateway-amazon-payments-advanced' ) . ' ' . $e->getMessage(), 'error' );
+			wc_add_notice( esc_html__( 'Error:', 'woocommerce-gateway-amazon-payments-advanced' ) . ' ' . $e->getMessage(), 'error' );
 		}
 	}
 
@@ -445,7 +445,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		$order->update_meta_data( 'amazon_timed_out_transaction', true );
 		$order->save();
 
-		$order->update_status( 'on-hold', __( 'Transaction with Amazon Pay is currently being validated.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+		$order->update_status( 'on-hold', esc_html__( 'Transaction with Amazon Pay is currently being validated.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 
 		// https://pay.amazon.com/it/developer/documentation/lpwa/201953810
 		// Make an ASYNC Authorize API call using a TransactionTimeout of 1440.
@@ -478,7 +478,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		wc_apa()->log( 'Info: No Authorize or Capture call.' );
 
 		// Mark as on-hold.
-		$order->update_status( 'on-hold', __( 'Amazon order opened. Use the "Amazon Pay" box to authorize and/or capture payment. Authorized payments must be captured within 7 days.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+		$order->update_status( 'on-hold', esc_html__( 'Amazon order opened. Use the "Amazon Pay" box to authorize and/or capture payment. Authorized payments must be captured within 7 days.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 
 		// Reduce stock levels.
 
@@ -520,7 +520,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		$result = WC_Amazon_Payments_Advanced_API_Legacy::handle_payment_authorization_response( $result, $order_id, false );
 		if ( $result ) {
 			// Mark as on-hold.
-			$order->update_status( 'on-hold', __( 'Amazon order opened. Use the "Amazon Pay" box to authorize and/or capture payment. Authorized payments must be captured within 7 days.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+			$order->update_status( 'on-hold', esc_html__( 'Amazon order opened. Use the "Amazon Pay" box to authorize and/or capture payment. Authorized payments must be captured within 7 days.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 
 			// Reduce stock levels.
 			if ( version_compare( WC_VERSION, '3.0', '<' ) ) {
@@ -531,7 +531,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 
 			wc_apa()->log( 'Info: Successfully authorized in order reference ' . $amazon_reference_id );
 		} else {
-			$order->update_status( 'failed', __( 'Could not authorize Amazon payment.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+			$order->update_status( 'failed', esc_html__( 'Could not authorize Amazon payment.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 
 			wc_apa()->log( 'Error: Failed to authorize in order reference ' . $amazon_reference_id );
 		}
@@ -596,7 +596,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 			wc_apa()->log( 'Info: Successfully captured in order reference ' . $amazon_reference_id );
 
 		} else {
-			$order->update_status( 'failed', __( 'Could not authorize Amazon payment.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+			$order->update_status( 'failed', esc_html__( 'Could not authorize Amazon payment.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 
 			wc_apa()->log( 'Error: Failed to capture in order reference ' . $amazon_reference_id );
 		}
@@ -635,7 +635,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 			WC()->session->set( 'amazon_declined_order_id', $order_id );
 			WC()->session->set( 'amazon_declined_with_cancel_order', true );
 		}
-		throw new Exception( $result->get_error_message() );
+		throw new Exception( esc_html( $result->get_error_message() ) );
 	}
 
 	/**
@@ -654,13 +654,13 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		$order = wc_get_order( $order_id );
 		if ( ! ( $order instanceof \WC_Order ) ) {
 			/* translators: Order number */
-			return new WP_Error( 'error', sprintf( __( 'Unable to refund order %s. Order id is invalid.', 'woocommerce-gateway-amazon-payments-advanced' ), $order_id ) );
+			return new WP_Error( 'error', sprintf( esc_html__( 'Unable to refund order %s. Order id is invalid.', 'woocommerce-gateway-amazon-payments-advanced' ), $order_id ) );
 		}
 
 		$amazon_capture_id = $order->get_meta( 'amazon_capture_id', true, 'edit' );
 		if ( empty( $amazon_capture_id ) ) {
 			/* translators: Order number */
-			return new WP_Error( 'error', sprintf( __( 'Unable to refund order %s. Order does not have Amazon capture reference. Make sure order has been captured.', 'woocommerce-gateway-amazon-payments-advanced' ), $order_id ) );
+			return new WP_Error( 'error', sprintf( esc_html__( 'Unable to refund order %s. Order does not have Amazon capture reference. Make sure order has been captured.', 'woocommerce-gateway-amazon-payments-advanced' ), $order_id ) );
 		}
 
 		$ret = WC_Amazon_Payments_Advanced_API_Legacy::refund_payment( $order_id, $amazon_capture_id, $refund_amount, $reason );
@@ -700,9 +700,9 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		$site_name = WC_Amazon_Payments_Advanced::get_site_name();
 
 		/* translators: Order number and site's name */
-		$seller_note = sprintf( __( 'Order %1$s from %2$s.', 'woocommerce-gateway-amazon-payments-advanced' ), $order->get_order_number(), rawurlencode( $site_name ) );
+		$seller_note = sprintf( esc_html__( 'Order %1$s from %2$s.', 'woocommerce-gateway-amazon-payments-advanced' ), $order->get_order_number(), rawurlencode( $site_name ) );
 		/* translators: Plugin version */
-		$version_note = sprintf( __( 'Created by WC_Gateway_Amazon_Pay/%1$s (Platform=WooCommerce/%2$s)', 'woocommerce-gateway-amazon-payments-advanced' ), WC_AMAZON_PAY_VERSION . '-legacy', WC()->version );
+		$version_note = sprintf( esc_html__( 'Created by WC_Gateway_Amazon_Pay/%1$s (Platform=WooCommerce/%2$s)', 'woocommerce-gateway-amazon-payments-advanced' ), WC_AMAZON_PAY_VERSION . '-legacy', WC()->version );
 
 		$request_args = array_merge(
 			array(
@@ -723,12 +723,12 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		$response = WC_Amazon_Payments_Advanced_API_Legacy::request( $request_args );
 
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( $response->get_error_message() );
+			throw new Exception( esc_html( $response->get_error_message() ) );
 		}
 
 		// @codingStandardsIgnoreStart
 		if ( isset( $response->Error->Message ) ) {
-			throw new Exception( (string) $response->Error->Message );
+			throw new Exception( esc_html( (string) $response->Error->Message ) );
 		}
 		// @codingStandardsIgnoreEnd
 
@@ -745,13 +745,13 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 
 			switch ( $constraint ) {
 				case 'BuyerEqualSeller':
-					throw new Exception( __( 'You cannot shop on your own store.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+					throw new Exception( esc_html__( 'You cannot shop on your own store.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 				case 'PaymentPlanNotSet':
-					throw new Exception( __( 'You have not selected a payment method from your Amazon account. Please choose a payment method for this order.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+					throw new Exception( esc_html__( 'You have not selected a payment method from your Amazon account. Please choose a payment method for this order.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 				case 'PaymentMethodNotAllowed':
-					throw new Exception( __( 'There has been a problem with the selected payment method from your Amazon account. Please update the payment method or choose another one.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+					throw new Exception( esc_html__( 'There has been a problem with the selected payment method from your Amazon account. Please update the payment method or choose another one.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 				case 'ShippingAddressNotSet':
-					throw new Exception( __( 'You have not selected a shipping address from your Amazon account. Please choose a shipping address for this order.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+					throw new Exception( esc_html__( 'You have not selected a shipping address from your Amazon account. Please choose a shipping address for this order.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 			}
 		}
 
@@ -927,7 +927,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 
 		wc_apa()->log( sprintf( 'Info: Continuing payment processing for order %s. Reference ID %s', $order_id, $amazon_reference_id ) );
 		// phpcs:ignore WordPress.Security.NonceVerification
-		$authorization_status = wc_clean( $_GET['AuthenticationStatus'] );
+		$authorization_status = wc_clean( wp_unslash( $_GET['AuthenticationStatus'] ) );
 		switch ( $authorization_status ) {
 			case 'Success':
 				$this->handle_sca_success( $order, $amazon_reference_id );
@@ -964,7 +964,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 			if ( 'async' === $this->authorization_mode && isset( $e->transaction_timed_out ) ) {
 				$this->process_async_auth( $order, $amazon_reference_id );
 			} else {
-				wc_add_notice( __( 'Error:', 'woocommerce-gateway-amazon-payments-advanced' ) . ' ' . $e->getMessage(), 'error' );
+				wc_add_notice( esc_html__( 'Error:', 'woocommerce-gateway-amazon-payments-advanced' ) . ' ' . $e->getMessage(), 'error' );
 				$redirect = wc_get_checkout_url();
 			}
 		}
@@ -991,7 +991,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		// Failure will mock AmazonRejected behaviour.
 		if ( 'Failure' === $authorization_status ) {
 			// Cancel order.
-			$order->update_status( 'cancelled', __( 'Could not authorize Amazon payment. Failure on MFA (Multi-Factor Authentication) challenge.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+			$order->update_status( 'cancelled', esc_html__( 'Could not authorize Amazon payment. Failure on MFA (Multi-Factor Authentication) challenge.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 			// Cancel order on amazon.
 			WC_Amazon_Payments_Advanced_API_Legacy::cancel_order_reference( $order, 'MFA Failure' );
 
@@ -999,12 +999,12 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 			$redirect = wc_apa()->get_gateway()->get_amazon_logout_url( wc_get_cart_url() );
 
 			// Adds notice and logging.
-			wc_add_notice( __( 'There was a problem authorizing your transaction using Amazon Pay. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+			wc_add_notice( esc_html__( 'There was a problem authorizing your transaction using Amazon Pay. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 			wc_apa()->log( 'MFA (Multi-Factor Authentication) Challenge Fail, Status "Failure", reference ' . $amazon_reference_id );
 		}
 
 		if ( 'Abandoned' === $authorization_status ) {
-			wc_add_notice( __( 'Authentication for the transaction was not completed, please try again selecting another payment instrument from your Amazon wallet.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+			wc_add_notice( esc_html__( 'Authentication for the transaction was not completed, please try again selecting another payment instrument from your Amazon wallet.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 			wc_apa()->log( 'MFA (Multi-Factor Authentication) Challenge Fail, Status "Abandoned", reference ' . $amazon_reference_id );
 		}
 
@@ -1036,7 +1036,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 	 */
 	public function maybe_render_timeout_transaction_order_received_text( $text, $order ) {
 		if ( $order && $order->has_status( 'on-hold' ) && $order->get_meta( 'amazon_timed_out_transaction', true, 'edit' ) ) {
-			$text = __( 'Your transaction with Amazon Pay is currently being validated. Please be aware that we will inform you shortly as needed.', 'woocommerce-gateway-amazon-payments-advanced' );
+			$text = esc_html__( 'Your transaction with Amazon Pay is currently being validated. Please be aware that we will inform you shortly as needed.', 'woocommerce-gateway-amazon-payments-advanced' );
 		}
 		return $text;
 	}
@@ -1212,12 +1212,12 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		if ( empty( $this->reference_id ) && empty( $this->access_token ) ) {
 			?>
 			<div class="woocommerce-info info wc-amazon-payments-advanced-info"><div id="pay_with_amazon"></div>
-				<?php echo esc_html( apply_filters( 'woocommerce_amazon_pa_checkout_message', __( 'Have an Amazon account?', 'woocommerce-gateway-amazon-payments-advanced' ) ) ); ?>
+				<?php echo esc_html( apply_filters( 'woocommerce_amazon_pa_checkout_message', esc_html__( 'Have an Amazon account?', 'woocommerce-gateway-amazon-payments-advanced' ) ) ); ?>
 			</div>
 			<?php
 		} else {
 			$logout_url      = $this->get_amazon_logout_url();
-			$logout_msg_html = '<div class="woocommerce-info info">' . apply_filters( 'woocommerce_amazon_pa_checkout_logout_message', __( 'You\'re logged in with your Amazon Account.', 'woocommerce-gateway-amazon-payments-advanced' ) ) . ' <a href="' . esc_url( $logout_url ) . '" id="amazon-logout">' . __( 'Log out &raquo;', 'woocommerce-gateway-amazon-payments-advanced' ) . '</a></div>';
+			$logout_msg_html = '<div class="woocommerce-info info">' . apply_filters( 'woocommerce_amazon_pa_checkout_logout_message', esc_html__( 'You\'re logged in with your Amazon Account.', 'woocommerce-gateway-amazon-payments-advanced' ) ) . ' <a href="' . esc_url( $logout_url ) . '" id="amazon-logout">' . esc_html__( 'Log out &raquo;', 'woocommerce-gateway-amazon-payments-advanced' ) . '</a></div>';
 			echo wp_kses_post( apply_filters( 'woocommerce_amazon_payments_logout_checkout_message_html', $logout_msg_html ) );
 		}
 
@@ -1628,8 +1628,10 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 	public function ajax_sca_processing() {
 		check_ajax_referer( 'sca_nonce', 'nonce' );
 		// Get $_POST and $_REQUEST compatible with process_checkout.
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		parse_str( $_POST['data'], $_POST );
+		if ( isset( $_POST['data'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			parse_str( wp_unslash( $_POST['data'] ), $_POST );
+		}
 		$_REQUEST = $_POST;
 
 		WC()->checkout()->process_checkout();
@@ -1688,10 +1690,10 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 		}
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET['amazon_payments_advanced'] ) ) {
-			$url = add_query_arg( 'amazon_payments_advanced', sanitize_text_field( $_GET['amazon_payments_advanced'] ), $url );
+			$url = add_query_arg( 'amazon_payments_advanced', sanitize_text_field( wp_unslash( $_GET['amazon_payments_advanced'] ) ), $url );
 		}
 		if ( ! empty( $_GET['access_token'] ) ) {
-			$url = add_query_arg( 'access_token',  sanitize_text_field( $_GET['access_token'] ), $url );
+			$url = add_query_arg( 'access_token', sanitize_text_field( wp_unslash( $_GET['access_token'] ) ), $url );
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		return $url;
@@ -1705,14 +1707,14 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 
 		if ( empty( $_POST['order_reference_id'] ) ) {
 			wp_send_json(
-				new WP_Error( 'amazon_missing_order_reference_id', __( 'Missing order reference ID.', 'woocommerce-gateway-amazon-payments-advanced' ) ),
+				new WP_Error( 'amazon_missing_order_reference_id', esc_html__( 'Missing order reference ID.', 'woocommerce-gateway-amazon-payments-advanced' ) ),
 				400
 			);
 		}
 
 		if ( empty( $this->access_token ) ) {
 			wp_send_json(
-				new WP_Error( 'amazon_missing_access_token', __( 'Missing access token. Make sure you are logged in.', 'woocommerce-gateway-amazon-payments-advanced' ) ),
+				new WP_Error( 'amazon_missing_access_token', esc_html__( 'Missing access token. Make sure you are logged in.', 'woocommerce-gateway-amazon-payments-advanced' ) ),
 				400
 			);
 		}
@@ -1725,7 +1727,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 			wp_send_json( $response );
 		} else {
 			wp_send_json(
-				new WP_Error( 'amazon_get_order_reference_failed', __( 'Failed to get order reference data. Make sure you are logged in and trying to access a valid order reference owned by you.', 'woocommerce-gateway-amazon-payments-advanced' ) ),
+				new WP_Error( 'amazon_get_order_reference_failed', esc_html__( 'Failed to get order reference data. Make sure you are logged in and trying to access a valid order reference owned by you.', 'woocommerce-gateway-amazon-payments-advanced' ) ),
 				400
 			);
 		}
@@ -1740,7 +1742,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Legacy extends WC_Gateway_Amazon_Payme
 	public function maybe_display_declined_notice() {
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET['amazon_declined'] ) ) {
-			wc_add_notice( __( 'There was a problem with previously declined transaction. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+			wc_add_notice( esc_html__( 'There was a problem with previously declined transaction. Please try placing the order again.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 		}
 	}
 

--- a/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
+++ b/includes/legacy/class-wc-gateway-amazon-payments-advanced-subscriptions-legacy.php
@@ -62,8 +62,8 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 			return $process;
 		}
 
-		$amazon_reference_id              = isset( $_POST['amazon_reference_id'] ) ? wc_clean( $_POST['amazon_reference_id'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$amazon_billing_agreement_id      = isset( $_POST['amazon_billing_agreement_id'] ) ? wc_clean( $_POST['amazon_billing_agreement_id'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$amazon_reference_id              = isset( $_POST['amazon_reference_id'] ) ? wc_clean( wp_unslash( $_POST['amazon_reference_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$amazon_billing_agreement_id      = isset( $_POST['amazon_billing_agreement_id'] ) ? wc_clean( wp_unslash( $_POST['amazon_billing_agreement_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$amazon_billing_agreement_details = WC()->session->get( 'amazon_billing_agreement_details' ) ? wc_clean( WC()->session->get( 'amazon_billing_agreement_details' ) ) : false;
 
 		if ( ! $amazon_billing_agreement_id && 'yes' === get_option( 'woocommerce_subscriptions_turn_off_automatic_payments' ) ) {
@@ -383,9 +383,9 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 			return new WP_Error(
 				'billing_agreemment_details_failed',
 				is_object( $response ) && ! empty( $response->Error ) && is_object( $response->Error->Message ) && ! empty( $response->Error->Message ) ?
-				$response->Error->Message :
+				esc_html( (string) $response->Error->Message ) :
 				/* Translators: The billing agreement id. */
-				sprintf( __( 'Amazon API responded with an unexpected error when requesting for "GetBillingAgreementDetails" of billing agreement with ID %s', 'woocommerce-gateway-amazon-payments-advanced' ), $amazon_billing_agreement_id )
+				sprintf( __( 'Amazon API responded with an unexpected error when requesting for "GetBillingAgreementDetails" of billing agreement with ID %s', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $amazon_billing_agreement_id ) )
 			);
 			//phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
@@ -436,7 +436,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 
 			wc_apa()->log( "Error: WP_Error '{$error_message}' for order {$order_id} with billing agreement: {$amazon_billing_agreement_id}.", null, $context );
 
-			throw new Exception( $error_message );
+			throw new Exception( esc_html( $error_message ) );
 
 		}
 
@@ -445,7 +445,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions_Legacy {
 			$error_message = (string) $response->Error->Message;
 			wc_apa()->log( "Error: API Error '{$error_message}' for order {$order_id} with billing agreement: {$amazon_billing_agreement_id}.", null, $context );
 
-			throw new Exception( $error_message );
+			throw new Exception( esc_html( $error_message ) );
 		}
 		// @codingStandardsIgnoreEnd
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Amazon Pay for WooCommerce ===
 Contributors: amazonpay, woocommerce, automattic, saucal, woothemes, akeda, jeffstieler, mikejolley, bor0, claudiosanches, royho, jamesrrodger, laurendavissmith001, dwainm, danreylop
-Tags: woocommerce, amazon, checkout, payments, e-commerce, ecommerce
+Tags: woocommerce, amazon, checkout, payments, ecommerce
 Requires at least: 5.5
 Tested up to: 6.8
 Stable tag: 2.6.0


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

This PR fixes issues reported by the WooCommerce Quality Insights Toolkit (QIT) and wordpress.org Plugin Check.

Changes include:

- Added proper escaping for dynamic output in exceptions, logs, and translated strings (`esc_html()`, `esc_html__()`, `sprintf()` with escaped values).
- Fixed text domain mismatch (`woocommerce` → `woocommerce-gateway-amazon-payments-advanced`).
- Added `wp_unslash()` before sanitizing all relevant `$_POST`, `$_GET`, `$_REQUEST`, and `$_COOKIE` inputs.
- Added `isset()` checks to prevent usage of undefined superglobal indexes.
- Replaced `wc_clean()` with `sanitize_text_field()` where appropriate for scalar input.
- Escaped dynamic values used in legacy API error handling and subscription flows.
- Updated `readme.txt`:
  - Reduced tags to 5.
  - Updated “Tested up to” to 6.8.

Closes https://app.clickup.com/t/86dzcek0a

### How to test the changes in this Pull Request:

1. Install the plugin on a clean WordPress 6.8+ environment with WooCommerce active.
2. Run the wordpress.org Plugin Check / QIT scan and confirm that previously reported escaping, unslash, and text-domain errors are resolved.
3. Test:
   - Checkout flow with Amazon Pay.
   - IPN handling (including invalid payload scenarios).
   - Refund actions from admin (AJAX and non-AJAX).
   - Subscription flows (if enabled).

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Fix: Resolve QIT and wordpress.org Plugin Check issues, including output escaping, input unslashing/sanitization, text domain mismatch, and readme metadata updates.