### PR TITLE
Fix internal erro

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-ipn-handler.php
+++ b/includes/class-wc-amazon-payments-advanced-ipn-handler.php
@@ -466,7 +466,16 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 			throw new Exception( 'Invalid order ID ' . $order_id );
 		}
 
-		$order    = apply_filters( 'woocommerce_amazon_pa_ipn_notification_order', $order, $notification );
+		if ( ! $order instanceof \WC_Order ) {
+			throw new Exception( 'Order not found for ID ' . $order_id );
+		}
+
+		$order = apply_filters( 'woocommerce_amazon_pa_ipn_notification_order', $order, $notification );
+
+		if ( ! $order instanceof \WC_Order ) {
+			throw new Exception( 'Invalid order returned from woocommerce_amazon_pa_ipn_notification_order filter' );
+		}
+
 		$order_id = $order->get_id(); // Refresh variable, in case it changed.
 
 		if ( 'amazon_payments_advanced' !== $order->get_payment_method() ) {


### PR DESCRIPTION
### All Submissions:
* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Add validation for the order object in `handle_notification_ipn_v2()` to prevent fatal errors when `wc_get_order()` returns `false`.

The IPN handler was calling `$order->get_id()` without verifying that `$order` is a valid `WC_Order` instance, causing a `Call to a member function get_id() on false` fatal error when the order doesn't exist in the database (e.g., deleted or migrated orders).

Two `instanceof \WC_Order` checks were added:
1. After `wc_get_order()` — handles cases where the order is not found.
2. After `apply_filters( 'woocommerce_amazon_pa_ipn_notification_order' )` — handles cases where a filter returns an invalid value.

In both cases, an `Exception` is thrown, which is already caught by the existing try/catch in the method.

Closes # .

### How to test the changes in this Pull Request:
1. Trigger an IPN notification with a non-existent order ID (e.g., a deleted order).
2. Verify that instead of a fatal error, the exception is caught and logged gracefully.
3. Verify that normal IPN processing for existing orders continues to work as expected.

### Other information:
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry
> Fix - Add order validation in IPN handler to prevent fatal error when order is not found.
