### PR TITLE
fix: add validation for order object in IPN handler to prevent except…

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-ipn-handler.php
+++ b/includes/class-wc-amazon-payments-advanced-ipn-handler.php
@@ -467,6 +467,9 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 		}
 
 		$order    = apply_filters( 'woocommerce_amazon_pa_ipn_notification_order', $order, $notification );
+		if ( ! is_a( $order, WC_Order::class ) ) {
+			throw new Exception( "Order not found for order ID $order_id" );
+		}
 		$order_id = $order->get_id(); // Refresh variable, in case it changed.
 
 		if ( 'amazon_payments_advanced' !== $order->get_payment_method() ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Adds a guard in WC_Amazon_Payments_Advanced_IPN_Handler::handle_notification_ipn_v2() to validate the order object after
the woocommerce_amazon_pa_ipn_notification_order filter runs. Previously, if wc_get_order() returned     
false (e.g. order not found), calling $order->get_id() would throw an uncaught fatal error. The fix throws a catchable
Exception instead, which propagates up to check_ipn_request()'s existing try/catch block — resulting in a
logged 400 response rather than a fatal crash.

Closes [#319](https://github.com/woocommerce/woocommerce-gateway-amazon-pay/issues/319).

### How to test the changes in this Pull Request:

> The error appears intermittently every few days in the server logs during IPN (Instant Payment Notification)
> processing from Amazon Pay. It is not consistently reproducible on demand.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Fix fatal error (Call to a member function get_id() on false) in IPN Handler v2 when the order associated with an
> incoming Amazon Pay notification cannot be found.
