### PR TITLE
Fix/86dy7jgmb/phone number forced for all payment methods

### DIFF
--- a/.github/workflows/php-unit-on-pr.yml
+++ b/.github/workflows/php-unit-on-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.3, 7.4, 8.0, 8.1 ]
+        php: [ 7.4, 8.0, 8.1 ]
     services:
       database:
         image: mysql:5.6

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -174,6 +174,13 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	protected $enable_login_app;
 
 	/**
+	 * Flag to suppress the phone required filter during base value lookup.
+	 *
+	 * @var bool
+	 */
+	private static $suppress_phone_filter = false;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -1058,6 +1065,10 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	 */
 	public function maybe_flag_phone_number_as_required( $option_value ) {
 
+		if ( self::$suppress_phone_filter ) {
+			return $option_value;
+		}
+
 		if ( ! $this->is_available() ) {
 			return $option_value;
 		}
@@ -1091,16 +1102,10 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
      * @return bool
      */
     public function phone_number_is_required_base() {
-		$filter_callback  = array( $this, 'maybe_flag_phone_number_as_required' );
-		$has_filter = has_filter( 'option_woocommerce_checkout_phone_field', $filter_callback );
-		if ( $has_filter ) {
-			remove_filter( 'option_woocommerce_checkout_phone_field', $filter_callback );
-		}
+		self::$suppress_phone_filter = true;
 		/** @see \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::get_core_fields */
 		$base_phone_required = 'required' === CartCheckoutUtils::get_phone_field_visibility();
-		if ( $has_filter ) {
-			add_filter('option_woocommerce_checkout_phone_field', $filter_callback);
-		}
+		self::$suppress_phone_filter = false;
 
         return $base_phone_required;
     }

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -4,6 +4,7 @@
  *
  * @package WC_Gateway_Amazon_Pay
  */
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 
 /**
  * WC_Gateway_Amazon_Payments_Advanced_Abstract
@@ -1087,6 +1088,25 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
      */
     public function phone_number_is_required() {
         return ( ! empty( WC()->cart ) ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping();
+    }
+
+    /**
+     * Indicates whether the phone was required without taking Amazon Pay into account
+     * @return bool
+     */
+    public function phone_number_is_required_base() {
+		$filter_callback  = array( $this, 'maybe_flag_phone_number_as_required' );
+		$has_filter = has_filter( 'option_woocommerce_checkout_phone_field', $filter_callback );
+		if ( $has_filter ) {
+			remove_filter( 'option_woocommerce_checkout_phone_field', $filter_callback );
+		}
+		/** @see \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::get_core_fields */
+		$base_phone_required = 'required' === CartCheckoutUtils::get_phone_field_visibility();
+		if ( $has_filter ) {
+			add_filter('option_woocommerce_checkout_phone_field', $filter_callback);
+		}
+
+        return $base_phone_required;
     }
 
 	/**

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -1061,6 +1061,15 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 			return $option_value;
 		}
 
+		$chosen_payment = ( WC()->session instanceof WC_Session ) ? WC()->session->get( 'chosen_payment_method' ) : null;
+		if ( empty( $chosen_payment ) && isset( $_POST['payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$chosen_payment = sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		}
+
+		if ( $this->id !== $chosen_payment ) {
+			return $option_value;
+		}
+
 		if ( empty( WC()->cart ) ) {
 			return $option_value;
 		}

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -1075,11 +1075,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 			return $option_value;
 		}
 
-		if ( ! method_exists( WC()->cart, 'needs_shipping' ) || ! WC()->cart->needs_shipping() ) {
-			return $option_value;
-		}
-
-		return 'required';
+        return $this->phone_number_is_required() ? 'required' : $option_value;
 	}
 
     /**

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -1081,6 +1081,14 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 		return 'required';
 	}
 
+    /**
+     * The phone number field is required for Amazon Pay
+     * @return bool
+     */
+    public function phone_number_is_required() {
+        return ( ! empty( WC()->cart ) ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping();
+    }
+
 	/**
 	 * Init common hooks on checkout_init hook
 	 */

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -297,6 +297,8 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'ledger_currency'                => $this->get_ledger_currency(),
 				'estimated_order_amount'         => self::get_estimated_order_amount(),
 				'overriden_fields_per_country'   => WC_Amazon_Payments_Advanced_Utils::get_non_required_fields_per_country(),
+				'phone_required'                 => $this->phone_number_is_required(),
+				'phone_required_base'            => $this->phone_number_is_required_base(),
 			),
 			$params
 		);

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -299,6 +299,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'overriden_fields_per_country'   => WC_Amazon_Payments_Advanced_Utils::get_non_required_fields_per_country(),
 				'phone_required'                 => $this->phone_number_is_required(),
 				'phone_required_base'            => $this->phone_number_is_required_base(),
+				'i18n_optional'                  => esc_html__( 'optional', 'woocommerce-gateway-amazon-payments-advanced' ),
 			),
 			$params
 		);

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
@@ -43,7 +43,6 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 	 * @return array
 	 */
 	public function get_payment_method_data() {
-		$phone_required = ! empty( WC()->cart ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping(); // TODO: use reusable service
 		return array(
 			'title'               => $this->settings['title'],
 			'description'         => $this->settings['description'],
@@ -51,7 +50,8 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 			'amazonPayPreviewUrl' => esc_url( wc_apa()->plugin_url . '/build/images/amazon-pay-preview.png' ),
 			'action'              => wc_apa()->get_gateway()->get_current_cart_action(),
 			'allowedCurrencies'   => $this->get_allowed_currencies(),
-			'phoneRequired'       => $phone_required,
+			'phoneRequired'       => wc_apa()->get_gateway()->phone_number_is_required(),
+			'phoneRequiredBase'   => wc_apa()->get_gateway()->phone_number_is_required_base(),
 		);
 	}
 

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
@@ -43,6 +43,7 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 	 * @return array
 	 */
 	public function get_payment_method_data() {
+		$phone_required = ! empty( WC()->cart ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping(); // TODO: use reusable service
 		return array(
 			'title'               => $this->settings['title'],
 			'description'         => $this->settings['description'],
@@ -50,6 +51,7 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 			'amazonPayPreviewUrl' => esc_url( wc_apa()->plugin_url . '/build/images/amazon-pay-preview.png' ),
 			'action'              => wc_apa()->get_gateway()->get_current_cart_action(),
 			'allowedCurrencies'   => $this->get_allowed_currencies(),
+			'phoneRequired'       => $phone_required,
 		);
 	}
 

--- a/src/js/non-block/amazon-wc-checkout.js
+++ b/src/js/non-block/amazon-wc-checkout.js
@@ -424,7 +424,7 @@
 				$label.append( '<span class="required" aria-hidden="true">*</span>' );
 			} else {
 				$field.removeAttr( 'required' );
-				$label.append( '<span class="optional">(optional)</span>' );
+				$label.append( '<span class="optional">(' + amazon_payments_advanced.i18n_optional + ')</span>' );
 			}
 		}
 

--- a/src/js/non-block/amazon-wc-checkout.js
+++ b/src/js/non-block/amazon-wc-checkout.js
@@ -416,9 +416,37 @@
 			$( '.wc-apa-send-confirm-ownership-code' ).on( 'click', sendConfirmationCode );
 		}
 
+		function updatePhoneFieldRequired( $field, isRequired ) {
+			var $label = $( 'label[for="' + $field.attr( 'id' ) + '"]' );
+			$label.find( 'span.required, span.optional' ).remove();
+			if ( isRequired ) {
+				$field.attr( 'required', '' );
+				$label.append( '<span class="required" aria-hidden="true">*</span>' );
+			} else {
+				$field.removeAttr( 'required' );
+				$label.append( '<span class="optional">(optional)</span>' );
+			}
+		}
+
+		function updatePhoneRequired() {
+			var phoneRequired = amazon_payments_advanced.phone_required;
+			var phoneRequiredBase = amazon_payments_advanced.phone_required_base;
+
+			if ( ! phoneRequired || phoneRequiredBase ) {
+				return;
+			}
+
+			var isAmazon = 'amazon_payments_advanced' === $( 'input[name=payment_method]:checked' ).val();
+			updatePhoneFieldRequired( $( '#billing_phone' ), isAmazon );
+			updatePhoneFieldRequired( $( '#shipping_phone' ), isAmazon );
+		}
+
 		initAmazonPaymentFields();
 
 		$( 'body' ).on( 'updated_checkout', initAmazonPaymentFields );
-		$( 'body' ).on( 'payment_method_selected', initAmazonPaymentFields );
+		$( 'body' ).on( 'payment_method_selected', function() {
+			initAmazonPaymentFields();
+			updatePhoneRequired();
+		} );
 	} );
 } )( jQuery );

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -18,7 +18,7 @@ import { renderAndInitAmazonCheckout } from '../../_renderAmazonButton';
  * @returns React component
  */
 const AmazonPayBtn = ( props ) => {
-	const { action, phoneRequired } = settings;
+	const { action, phoneRequired, phoneRequiredBase } = settings;
 
 	useEffect( () => {
 		const unsubscribe = props.eventRegistration.onCheckoutSuccess(
@@ -41,32 +41,46 @@ const AmazonPayBtn = ( props ) => {
 	] );
 
 	useEffect( () => {
-		if ( 'PayOnly' === action ) {
+		if ( 'PayOnly' === action || ! phoneRequired || phoneRequiredBase ) {
 			return;
 		}
-		if ( ! phoneRequired ) {
-			return;
-		}
+		const defaultFieldsSettings = window.wc?.wcSettings?.getSetting?.( 'defaultFields', {} );
+		const phoneLabel = defaultFieldsSettings?.phone?.label || __( 'Phone', 'woocommerce-gateway-amazon-payments-advanced' );
+		const phoneOptionalLabel = defaultFieldsSettings?.phone?.optionalLabel || __( 'Phone (optional)', 'woocommerce-gateway-amazon-payments-advanced' );
+
 		const phoneIds = [ 'billing-phone', 'shipping-phone' ];
+		const wcDefaultPhone = window.wc?.wcSettings?.defaultFields?.phone;
+
+		if ( wcDefaultPhone ) {
+			wcDefaultPhone.required = true;
+		}
 		phoneIds.forEach( ( id ) => {
 			const field = document.getElementById( id );
-			if ( field ) {
-				field.setAttribute( 'required', '' );
-				const label = document.querySelector( `label[for="${ id }"]` );
-				if ( field ) {
-					label.innerHTML = __( 'Phone', 'woocommerce-gateway-amazon-payments-advanced' );
-				}
+			if ( ! field ) {
+				return;
+			}
+			field.setAttribute( 'required', '' );
+			const label = document.querySelector( `label[for="${ id }"]` );
+			if ( label ) {
+				label.textContent = phoneLabel;
 			}
 		} );
+
 		return () => {
+			// Restore defaultFields to the base WC option value so fields that appear after
+			// Amazon Pay is deselected (e.g. billing-phone after same-address toggle) render correctly.
+			if ( wcDefaultPhone ) {
+				wcDefaultPhone.required = false;
+			}
 			phoneIds.forEach( ( id ) => {
 				const field = document.getElementById( id );
-				if ( field ) {
-					field.removeAttribute( 'required' );
-					const label = document.querySelector( `label[for="${ id }"]` );
-					if ( field ) {
-						label.innerHTML = __( 'Phone (optional)', 'woocommerce-gateway-amazon-payments-advanced' );
-					}
+				if ( ! field ) {
+					return;
+				}
+				field.removeAttribute( 'required' );
+				const label = document.querySelector( `label[for="${ id }"]` );
+				if ( label ) {
+					label.textContent = phoneOptionalLabel;
 				}
 			} );
 		};
@@ -80,7 +94,7 @@ const AmazonPayBtn = ( props ) => {
 				}
 				const shippingPhone = document.getElementById( 'shipping-phone' );
 				const billingPhone = document.getElementById( 'billing-phone' );
-				
+
 				if ( ! shippingPhone?.value && ! billingPhone?.value ) {
 					return {
 						type: 'error',

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -18,7 +18,7 @@ import { renderAndInitAmazonCheckout } from '../../_renderAmazonButton';
  * @returns React component
  */
 const AmazonPayBtn = ( props ) => {
-	const { action } = settings;
+	const { action, phoneRequired } = settings;
 
 	useEffect( () => {
 		const unsubscribe = props.eventRegistration.onCheckoutSuccess(
@@ -42,6 +42,9 @@ const AmazonPayBtn = ( props ) => {
 
 	useEffect( () => {
 		if ( 'PayOnly' === action ) {
+			return;
+		}
+		if ( ! phoneRequired ) {
 			return;
 		}
 		const phoneIds = [ 'billing-phone', 'shipping-phone' ];

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -41,6 +41,27 @@ const AmazonPayBtn = ( props ) => {
 	] );
 
 	useEffect( () => {
+		if ( 'PayOnly' === action ) {
+			return;
+		}
+		const phoneIds = [ 'billing-phone', 'shipping-phone' ];
+		phoneIds.forEach( ( id ) => {
+			const field = document.getElementById( id );
+			if ( field ) {
+				field.setAttribute( 'required', '' );
+			}
+		} );
+		return () => {
+			phoneIds.forEach( ( id ) => {
+				const field = document.getElementById( id );
+				if ( field ) {
+					field.removeAttribute( 'required' );
+				}
+			} );
+		};
+	}, [ action ] );
+
+	useEffect( () => {
 		const unsubscribe = props.eventRegistration.onPaymentSetup(
 			async () => {
 				if ( 'PayOnly' === action ) {

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -44,45 +44,16 @@ const AmazonPayBtn = ( props ) => {
 		if ( 'PayOnly' === action || ! phoneRequired || phoneRequiredBase ) {
 			return;
 		}
-		const defaultFieldsSettings = window.wc?.wcSettings?.getSetting?.( 'defaultFields', {} );
-		const phoneLabel = defaultFieldsSettings?.phone?.label || __( 'Phone', 'woocommerce-gateway-amazon-payments-advanced' );
-		const phoneOptionalLabel = defaultFieldsSettings?.phone?.optionalLabel || __( 'Phone (optional)', 'woocommerce-gateway-amazon-payments-advanced' );
 
-		const phoneIds = [ 'billing-phone', 'shipping-phone' ];
 		const wcDefaultPhone = window.wc?.wcSettings?.defaultFields?.phone;
-
 		if ( wcDefaultPhone ) {
 			wcDefaultPhone.required = true;
 		}
-		phoneIds.forEach( ( id ) => {
-			const field = document.getElementById( id );
-			if ( ! field ) {
-				return;
-			}
-			field.setAttribute( 'required', '' );
-			const label = document.querySelector( `label[for="${ id }"]` );
-			if ( label ) {
-				label.textContent = phoneLabel;
-			}
-		} );
 
 		return () => {
-			// Restore defaultFields to the base WC option value so fields that appear after
-			// Amazon Pay is deselected (e.g. billing-phone after same-address toggle) render correctly.
 			if ( wcDefaultPhone ) {
 				wcDefaultPhone.required = false;
 			}
-			phoneIds.forEach( ( id ) => {
-				const field = document.getElementById( id );
-				if ( ! field ) {
-					return;
-				}
-				field.removeAttribute( 'required' );
-				const label = document.querySelector( `label[for="${ id }"]` );
-				if ( label ) {
-					label.textContent = phoneOptionalLabel;
-				}
-			} );
 		};
 	}, [ action ] );
 

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -49,6 +49,10 @@ const AmazonPayBtn = ( props ) => {
 			const field = document.getElementById( id );
 			if ( field ) {
 				field.setAttribute( 'required', '' );
+				const label = document.querySelector( `label[for="${ id }"]` );
+				if ( field ) {
+					label.innerHTML = __( 'Phone', 'woocommerce-gateway-amazon-payments-advanced' );
+				}
 			}
 		} );
 		return () => {
@@ -56,6 +60,10 @@ const AmazonPayBtn = ( props ) => {
 				const field = document.getElementById( id );
 				if ( field ) {
 					field.removeAttribute( 'required' );
+					const label = document.querySelector( `label[for="${ id }"]` );
+					if ( field ) {
+						label.innerHTML = __( 'Phone (optional)', 'woocommerce-gateway-amazon-payments-advanced' );
+					}
 				}
 			} );
 		};


### PR DESCRIPTION
### All Submissions:

  * [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
  * [ ] Have you written new tests for your changes, as applicable?
  * [ ] Have you successfully run tests with your changes locally?

  ### Changes proposed in this Pull Request:

  Fixes Amazon Pay forcing the phone field as required for all payment methods. Phone should only be required when Amazon Pay is the selected payment method AND the cart contains shippable products.

  **Root cause:** The `maybe_flag_phone_number_as_required` filter on `option_woocommerce_checkout_phone_field` was applied globally, causing the phone field to be marked as required regardless of which payment method was selected in the frontend.

  **Changes:**
  
  - Added `phone_number_is_required_base()` to the abstract gateway class, which returns the WooCommerce phone field setting without Amazon Pay's filter interference. This is used as the authoritative "original state" for frontend cleanup.
  - **Blocks (React):** Mutates `window.wc.wcSettings.defaultFields.phone.required` on Amazon Pay selection/deselection. Since `useFormFields` calls `prepareFormFields` on every render (no memoization), the next WC-triggered re-render (e.g. cart sync) picks up the updated value and React re-renders the
  field with the correct `required` state and label automatically — no direct DOM manipulation needed.
  - **Classic Checkout (jQuery):** Added `updatePhoneFieldRequired()` responding to `payment_method_selected` to update both the `required` attribute and the label marker (`abbr.required` / `span.optional`). Note: `update_checkout` AJAX does not re-render address fields (only order review fragments), so
  JS-side handling is required here as well.

  Closes # .
  
  ### How to test the changes in this Pull Request:

  **WooCommerce Blocks checkout:**

  1. Enable a payment method other than Amazon Pay (e.g. Cash on Delivery). Ensure the WooCommerce phone field setting is set to "Optional".
  2. Load the checkout page. Verify phone field is not required.
  3. Select Amazon Pay as the payment method. Verify phone field becomes required (label shows `*`).
  4. Switch back to another payment method. Verify phone field returns to optional (label shows `(optional)`).
  5. Repeat steps 3–4 with "Use same address for billing" checked, then uncheck it after selecting Amazon Pay — verify billing phone also becomes required when it appears.
  6. Reload the page with Amazon Pay pre-selected (it may persist in session). Switch to another method — verify phone is no longer required.

  **Classic Checkout:**
  
  1. Same setup as above using the classic checkout page (non-Blocks).
  2. Select Amazon Pay — verify `#billing_phone` and `#shipping_phone` become required and label shows `*`.
  3. Switch to another payment method — verify both fields return to optional with `(optional)` label.
  
  **PayOnly action (no shipping):**

  1. Add a virtual/downloadable product to cart (no shipping needed).
  2. Verify phone field is never forced as required regardless of payment method selected.                                                                                                                                                                                                       
  
  ### Other information:

  * [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

  ### Changelog entry
  
  > Fix phone number field being incorrectly forced as required for all payment methods. Phone is now only required when Amazon Pay is selected and the cart contains shippable products, both in WooCommerce Blocks and Classic Checkout.