### PR TITLE
fix incompatibility with php 8.5

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -854,7 +854,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 
 				$finfo = new finfo( FILEINFO_MIME_TYPE );
 				$ext   = $finfo->file( $pem_file['tmp_name'] );
-				if ( 'text/plain' === $ext && isset( $pem_file['tmp_name'] ) ) {
+				if ( in_array( $ext, array( 'text/plain', 'text/x-ssh-private-key' ), true ) && isset( $pem_file['tmp_name'] ) ) {
 					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 					$private_key = file_get_contents( $pem_file['tmp_name'] );
 					$this->save_private_key( $private_key );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Closes #339.

### How to test the changes in this Pull Request:

1. Install the plugin in an environment using PHP 8.5.
2. Configure the plugin either with the manual flow or the automatic onboarding.
3. The plugin should be correctly configured.

### Changelog entry

> Fix - Incompatibility with PHP 8.5.