### PR TITLE
chore: drop PHP 7.3 from CI test matrix

### DIFF
--- a/.github/workflows/php-unit-on-pr.yml
+++ b/.github/workflows/php-unit-on-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.3, 7.4, 8.0, 8.1 ]
+        php: [ 7.4, 8.0, 8.1 ]
     services:
       database:
         image: mysql:5.6


### PR DESCRIPTION
WordPress 7.0 requires PHP 7.4+. Running the test environment with PHP 7.3 fails with:
"Your server is running PHP version 7.3.33 but WordPress 7.0 requires at least 7.4."

### All Submissions:

* [ ] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
