### PR TITLE
Chore/86e26u1yb/amazon pay sdk php 2 7 2 update

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Amazon Pay Changelog ***
 
+= 2.6.3 - 2026-xx-xx =
+
+* Update - Amazon Pay SDK to v2.7.2.
+
 = 2.6.2 - 2026-07-22 =
 
 * Fix - Fatal error in the IPN handler (v2) when the related order could not be retrieved.

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "wp-cli/wp-cli-bundle": "*"
     },
     "require": {
-        "amzn/amazon-pay-api-sdk-php": "2.7.0",
+        "amzn/amazon-pay-api-sdk-php": "2.7.2",
         "php": "7.*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3425b3f410b88f017593142db4782ee",
+    "content-hash": "bb700f53e2490b82274ac56255568900",
     "packages": [
         {
             "name": "amzn/amazon-pay-api-sdk-php",
-            "version": "2.7.0",
+            "version": "2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amzn/amazon-pay-api-sdk-php.git",
-                "reference": "ed3416f5ae7132bdd9007f6f83f36cb541b83793"
+                "reference": "f78ef40b67061458d8564d3ee3e8dab1b72abca0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amzn/amazon-pay-api-sdk-php/zipball/ed3416f5ae7132bdd9007f6f83f36cb541b83793",
-                "reference": "ed3416f5ae7132bdd9007f6f83f36cb541b83793",
+                "url": "https://api.github.com/repos/amzn/amazon-pay-api-sdk-php/zipball/f78ef40b67061458d8564d3ee3e8dab1b72abca0",
+                "reference": "f78ef40b67061458d8564d3ee3e8dab1b72abca0",
                 "shasum": ""
             },
             "require": {
@@ -57,9 +57,9 @@
             ],
             "support": {
                 "issues": "https://github.com/amzn/amazon-pay-api-sdk-php/issues",
-                "source": "https://github.com/amzn/amazon-pay-api-sdk-php/tree/2.7.0"
+                "source": "https://github.com/amzn/amazon-pay-api-sdk-php/tree/2.7.2"
             },
-            "time": "2025-05-29T10:21:22+00:00"
+            "time": "2026-07-02T04:48:12+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,10 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 
 == Changelog ==
 
+= 2.6.3 - 2026-xx-xx =
+
+* Update - Amazon Pay SDK to v2.7.2.
+
 = 2.6.2 - 2026-07-22 =
 
 * Fix - Fatal error in the IPN handler (v2) when the related order could not be retrieved.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Bumps `amzn/amazon-pay-api-sdk-php` from `2.7.0` to `2.7.2`.

SDK 2.7.2 only adds two new methods, `createStore` and `updateStore`, for managing stores within merchant accounts — restricted to allowlisted Solution Providers and not called anywhere in this plugin. No existing SDK method signature changed (confirmed via the upstream diff: https://github.com/amzn/amazon-pay-api-sdk-php/compare/2.7.0...2.7.2). The only other change is an internal `curl_close` -> `unset` fix in `HttpCurl.php`.

Closes # .

### How to test the changes in this Pull Request:

1. Pull this branch and run `composer install`.
2. Confirm `vendor/amzn/amazon-pay-api-sdk-php` is at `2.7.2` (check `Client::SDK_VERSION`).
3. Run a checkout with Amazon Pay (classic checkout and Checkout Blocks) and confirm the order completes normally; also verify a refund from WooCommerce admin still works.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Amazon Pay SDK to v2.7.2.